### PR TITLE
fix tests + easier install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.jar
 *.war
 *.ear
+*.pyc
 
 # Intellij Files & Dir #
 *.iml
@@ -26,3 +27,4 @@ logs/
 
 # Examples Stuff
 dependency-reduced-pom.xml
+

--- a/cdap-authentication-clients/python/README.md
+++ b/cdap-authentication-clients/python/README.md
@@ -14,13 +14,19 @@ external Python applications.
  - LDAP
  - JAASPI
 
+## Installation
+ To install CDAP Authentication Client, run:
+```
+    $ python setup.py install
+```
+
 ## Usage
 
  To use the Authentication Client Python API, include these imports in your Python script:
 
 ```
-    from Config import Config
-    from BasicAuthenticationClient import BasicAuthenticationClient
+    from cdap_auth_client import Config
+    from cdap_auth_client import BasicAuthenticationClient
 ```
 
 ## Example

--- a/cdap-authentication-clients/python/cdap_auth_client/AbstractAuthenticationClient.py
+++ b/cdap-authentication-clients/python/cdap_auth_client/AbstractAuthenticationClient.py
@@ -40,6 +40,7 @@ class AbstractAuthenticationClient(AuthenticationClient):
     ACCESS_TOKEN_KEY = u"access_token"
     AUTH_URI_KEY = u"auth_uri"
     AUTHENTICATION_HEADER_PREFIX_BASIC = u"Basic "
+    GATEWAY_VERSION = u'/v2'
     HTTP_PROTOCOL = u"http"
     HTTPS_PROTOCOL = u"https"
     EXPIRES_IN_KEY = u"expires_in"
@@ -81,9 +82,9 @@ class AbstractAuthenticationClient(AuthenticationClient):
             raise ValueError(u"Base authentication"
                              u" client is not configured!")
         LOG.debug(u"Try to get the authentication URI from "
-                  u"the gateway server: {}.", self.__base_url)
+                  u"the gateway server: {}.", self.__base_url + GATEWAY_VERSION + '/ping')
 
-        response = requests.get(self.__base_url,
+        response = requests.get(self.__base_url + GATEWAY_VERSION + '/ping',
                                 verify=self.ssl_verification_status())
         result = None
         if response.status_code == hl.UNAUTHORIZED:

--- a/cdap-authentication-clients/python/setup.py
+++ b/cdap-authentication-clients/python/setup.py
@@ -22,5 +22,7 @@ setup(name='cdap-auth-client',
     description='Authentication client for Cask Data Application Platform',
     author='Cask Data',
     author_email='cask-dev@googlegroups.com',
+    install_requires=["six"],
     packages=find_packages(),
     )
+

--- a/cdap-authentication-clients/python/tests/BasicAuthenticationClientTest.py
+++ b/cdap-authentication-clients/python/tests/BasicAuthenticationClientTest.py
@@ -24,11 +24,11 @@ import os
 import sys
 import inspect
 
-currentdir = os.path.dirname(
+current_dir = os.path.dirname(
     os.path.abspath(inspect.getfile(inspect.currentframe())))
-parentdir = os.path.dirname(currentdir)
-srcdir = parentdir + '/cdap_auth_client'
-sys.path.insert(0, srcdir)
+parent_dir = os.path.dirname(current_dir)
+src_dir = parent_dir + '/cdap_auth_client'
+sys.path.insert(0, src_dir)
 
 from AuthDisabledHandler import AuthDisabledHandler
 from EmptyUrlListHandler import EmptyUrlListHandler

--- a/cdap-authentication-clients/python/tests/BasicAuthenticationClientTest.py
+++ b/cdap-authentication-clients/python/tests/BasicAuthenticationClientTest.py
@@ -27,7 +27,8 @@ import inspect
 currentdir = os.path.dirname(
     os.path.abspath(inspect.getfile(inspect.currentframe())))
 parentdir = os.path.dirname(currentdir)
-sys.path.insert(0, parentdir)
+srcdir = parentdir + '/cdap_auth_client'
+sys.path.insert(0, srcdir)
 
 from AuthDisabledHandler import AuthDisabledHandler
 from EmptyUrlListHandler import EmptyUrlListHandler
@@ -46,11 +47,9 @@ import TestConstants
 class BasicAuthenticationClientTest(unittest.TestCase):
 
     def setUp(self):
-
         self.__authentication_client = BasicAuthenticationClient()
         self.__local_test_server = SimpleTCPServer(
             (u"localhost", TestConstants.SERVER_PORT), AuthenticationHandler)
-        self.__local_test_server.allow_reuse_address = True
         self.__server_thread = threading.\
             Thread(target=self.__local_test_server.serve_forever)
         self.__server_thread.start()
@@ -71,12 +70,12 @@ class BasicAuthenticationClientTest(unittest.TestCase):
             .start()
 
     def tearDown(self):
-        self.__local_test_server.server_close()
         self.__local_test_server.shutdown()
-        self.empty_response_server.server_close()
+        self.__local_test_server.server_close()
         self.empty_response_server.shutdown()
-        self.auth_disabled_server.server_close()
+        self.empty_response_server.server_close()
         self.auth_disabled_server.shutdown()
+        self.auth_disabled_server.server_close()
 
     def test_auth_is_auth_enabled(self):
         config = Config().read_from_file(u"auth_config.json")
@@ -92,7 +91,6 @@ class BasicAuthenticationClientTest(unittest.TestCase):
         self.assertEqual(TestConstants.TOKEN_TYPE, access_token.token_type)
         self.assertEqual(TestConstants.TOKEN_LIFE_TIME,
                          access_token.expires_in)
-        self.__local_test_server.server_close()
 
     def test_not_authorization_get_access_token(self):
         self.__authentication_client.username = u"fail"


### PR DESCRIPTION
Change sys.path.insert to point to the src directory, instead of simply to the parent directory.

Change BasicAuthenticationHandlerTest: remove a server_close from a test case, because it is being done in tearDown() already.
Also swapped the ordering of tcpserver.shutdown() and tcpserver.server_close(), because exceptions in the server threads were being thrown (even though the tests were passing) According to; https://hg.python.org/cpython/file/c6880edaf6f3/Lib/SocketServer.py, the server_close() closes the underlying socket, which should be done after the listening thread is shut down, not before.

Change setup.py to automatically install a dependency of the project - a module named 'six'.
