### PR TITLE
Remove unnecessary slf4j bindings from authentication-client

### DIFF
--- a/cdap-authentication-clients/java/pom.xml
+++ b/cdap-authentication-clients/java/pom.xml
@@ -39,20 +39,12 @@
       <artifactId>cdap-common</artifactId>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>log4j-over-slf4j</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,13 +63,9 @@
   <properties>
     <cdap.version>2.5.0</cdap.version>
     <commons.lang.version>2.5</commons.lang.version>
-    <logback.version>1.0.9</logback.version>
-    <log4j.over.slf4j.version>1.7.7</log4j.over.slf4j.version>
+    <slf4j.version>1.7.5</slf4j.version>
     <gson.version>2.2.4</gson.version>
     <guava.version>13.0.1</guava.version>
-    <rs-api.version>2.0</rs-api.version>
-    <jersey.version>2.4.1</jersey.version>
-    <mockito.version>1.9.5</mockito.version>
     <junit.version>4.11</junit.version>
   </properties>
 
@@ -107,24 +103,14 @@
         <version>${cdap.version}</version>
       </dependency>
       <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-core</artifactId>
-        <version>${logback.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>${logback.version}</version>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
         <version>${commons.lang.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>log4j-over-slf4j</artifactId>
-        <version>${log4j.over.slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Same as this: https://github.com/caskdata/cdap-clients/pull/39 , https://github.com/caskdata/cdap-clients/pull/40

but into release/1.0.0
