### PR TITLE
[cyb-59] JS fetch auth library

### DIFF
--- a/cdap-authentication-clients/javascript/Build.md
+++ b/cdap-authentication-clients/javascript/Build.md
@@ -1,0 +1,50 @@
+# Build procedure.
+
+Build process is implemented with [Grunt](http://gruntjs.com/).
+
+To set up all dependencies use next shell commands:
+
+```
+# npm install -g grunt-cli
+# npm install -g bower
+$ npm install
+$ bower install
+```
+
+## Tests
+
+```
+$ grunt test
+```
+
+NOTE: currently there is problem running browser tests with Grunt. To run browser test please
+open ```test/client.html``` in your favourite browsers.
+
+## Build
+
+```
+$ grunt build
+```
+
+## Default behaviour
+
+```
+$ grunt
+```
+
+Is equal to:
+```
+$ grunt test && grunt build
+```
+
+# Build artifacts location
+
+## Browser version
+```
+<project_dir>/dist/browser
+```
+
+## NodeJS version
+```
+<project_dir>/dist/nodejs
+```

--- a/cdap-authentication-clients/javascript/Gruntfile.js
+++ b/cdap-authentication-clients/javascript/Gruntfile.js
@@ -55,7 +55,6 @@ module.exports = function (grunt) {
 
     grunt.registerTask('test', [
 //        'mocha',
-        'open:browserTest',
         'mochaTest'
     ]);
     grunt.registerTask('build', [

--- a/cdap-authentication-clients/javascript/Gruntfile.js
+++ b/cdap-authentication-clients/javascript/Gruntfile.js
@@ -74,5 +74,4 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-mocha-test');
-    grunt.loadNpmTasks('grunt-open');
 };

--- a/cdap-authentication-clients/javascript/Gruntfile.js
+++ b/cdap-authentication-clients/javascript/Gruntfile.js
@@ -1,0 +1,79 @@
+module.exports = function (grunt) {
+    'use strict';
+    // Project configuration
+    grunt.initConfig({
+        // Metadata
+        pkg: grunt.file.readJSON('package.json'),
+        // Task configuration
+        // Browser side tests
+        /**
+         * temporary doesn`t work.
+         * More investigation required.
+         */
+/*        mocha: {
+            browser: {
+                src: ['test/client.html'],
+                options: {
+                    run: true,
+                    reporter: 'Nyan',
+                },
+            },
+        },*/
+        // Node.JS side tests
+        mochaTest: {
+            nodejs: {
+                src: ['test/authmanager-spec.js']
+            },
+        },
+        concat: {
+            browser_dist: {
+                src: ['src/base64.js', 'src/helper-browser.js', 'src/authmanager.js'],
+                dest: 'tmp/browser/<%= pkg.name %>.js'
+            },
+        },
+        copy: {
+            nodejs_package: {
+                expand: true,
+                cwd: 'src/nodejs/',
+                src: ['*.json', '*.js'],
+                dest: 'dist/nodejs/<%= pkg.name %>/'
+            },
+            nodejs_src: {
+                expand: true,
+                cwd: 'src/',
+                src: ['helper-node.js', 'authmanager.js'],
+                dest: 'dist/nodejs/<%= pkg.name %>/'
+            },
+        },
+        uglify: {
+            browser_dist: {
+                src: '<%= concat.browser_dist.dest %>',
+                dest: 'dist/browser/<%= pkg.name %>.min.js'
+            }
+        }
+    });
+
+    grunt.registerTask('test', [
+//        'mocha',
+        'open:browserTest',
+        'mochaTest'
+    ]);
+    grunt.registerTask('build', [
+        'concat',
+        'uglify',
+        'copy:nodejs_src',
+        'copy:nodejs_package'
+    ]);
+    // Default task
+    grunt.registerTask('default', [
+        'test',
+        'build'
+    ]);
+
+    // These plugins provide necessary tasks
+    grunt.loadNpmTasks('grunt-contrib-concat');
+    grunt.loadNpmTasks('grunt-contrib-copy');
+    grunt.loadNpmTasks('grunt-contrib-uglify');
+    grunt.loadNpmTasks('grunt-mocha-test');
+    grunt.loadNpmTasks('grunt-open');
+};

--- a/cdap-authentication-clients/javascript/Readme.md
+++ b/cdap-authentication-clients/javascript/Readme.md
@@ -1,0 +1,62 @@
+# CDAP Client JavaScript library
+
+Authentication client JavaScript API for CASK reactor.
+
+## Supported Actions
+
+- checking if authentication is available from the server side.
+- authentication
+
+## Installation
+
+### Web browser
+Copy ```<project_root>/dist/browser/cdap-auth-client.min.js``` to project depends on it.
+
+### NodeJS
+1. Copy ```<project_root>/dist/nodejs/cdap-auth-client``` to ```node_modules``` directory
+of your project.
+2. ```cd <you_project_root>/node_modules/cdap-auth-client```.
+3. ```npm install```. This command will install all dependencies for ```cdap-auth-client```.
+
+## Usage
+
+ To use the Authentication client JavaScript API, include these script tag in your index.html:
+
+### Web browser:
+```
+<script type="text/javascript" src="cdap-auth-client.min.js"></script>
+```
+
+### Node.JS:
+```
+var CDAPAuthManager = require('cdap-auth-client');
+```
+
+## Tracker object
+Methods:
+
+'isAuthEnabled()'    - checks if authentication is enabled from the server side.
+                       Returns: true/false
+'getToken()'         - authenticates and returns token info.
+                       Returns: {
+                           token: '',        - token value
+                           type: ''          - token type. Currently 'Bearer' is only supported.
+                       }
+
+## Example
+
+Create a ```CDAPAuthManager``` instance, specifying the 'username' and 'password' fields. 
+Optional configurations that can be set (and their default values):
+
+  - host: 'localhost' (DNS name or IP-address of the Reactor gateway server.)
+  - port: 10000 (Number of a port the Reactor gateway server works on)
+  - ssl: False (use HTTP protocol)
+
+```
+    var manager = new CDAPAuthManager('username', 'password'),
+        tokenInfo;
+
+    if (manager.isAuthEnabled()) {
+        tokenInfo = manager.getToken();
+    }
+```

--- a/cdap-authentication-clients/javascript/Readme.md
+++ b/cdap-authentication-clients/javascript/Readme.md
@@ -59,6 +59,7 @@ Optional configurations that can be set (and their default values):
   - ssl: False (use HTTP protocol)
 
 ```
+
     var manager = new CDAPAuthManager(),
         tokenInfo;
 

--- a/cdap-authentication-clients/javascript/Readme.md
+++ b/cdap-authentication-clients/javascript/Readme.md
@@ -42,6 +42,12 @@ Methods:
                            token: '',        - token value
                            type: ''          - token type. Currently 'Bearer' is only supported.
                        }
+'configure(config)'  - sets up username and password for authentication manager.
+                       config - {
+                           username: '',
+                           password: ''
+                       }
+'setConnectionInfo(hostname, port, ssl) - sets up connection data.
 
 ## Example
 
@@ -53,8 +59,14 @@ Optional configurations that can be set (and their default values):
   - ssl: False (use HTTP protocol)
 
 ```
-    var manager = new CDAPAuthManager('username', 'password'),
+    var manager = new CDAPAuthManager(),
         tokenInfo;
+
+    manager.configure({
+        username: 'username',
+        password: 'password'
+    });
+    manager.setConnectionInfo('localhost', 10000, false);
 
     if (manager.isAuthEnabled()) {
         tokenInfo = manager.getToken();

--- a/cdap-authentication-clients/javascript/bower.json
+++ b/cdap-authentication-clients/javascript/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "cask-auth-manager",
+  "version": "1.0.0",
+  "homepage": "https://github.com/cybervisiontech/cdap-clients",
+  "authors": [
+    "Constantine Povietkin <kpovetkin@cask.co>"
+  ],
+  "moduleType": [
+    "amd",
+    "node"
+  ],
+  "license": "Apache",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "expect": "~0.3.1",
+    "mocha": "~1.21.4"
+  }
+}

--- a/cdap-authentication-clients/javascript/package.json
+++ b/cdap-authentication-clients/javascript/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cdap-auth-client",
+  "version": "1.0.0",
+  "dependencies": {
+    "node-curl": "^0.3.3"
+  },
+  "devDependencies": {
+    "expect.js": "^0.3.1",
+    "grunt": "~0.4.2",
+    "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-copy": "^0.6.0",
+    "grunt-contrib-uglify": "~0.2.7",
+    "grunt-mocha": "^0.4.11",
+    "grunt-mocha-test": "^0.12.0",
+    "httpsync": "0.0.8",
+    "nock": "^0.48.0",
+    "sinon": "^1.10.3"
+  }
+}

--- a/cdap-authentication-clients/javascript/package.json
+++ b/cdap-authentication-clients/javascript/package.json
@@ -2,7 +2,7 @@
   "name": "cdap-auth-client",
   "version": "1.0.0",
   "dependencies": {
-    "node-curl": "^0.3.3"
+    "http-sync": "0.0.5"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",
@@ -12,7 +12,6 @@
     "grunt-contrib-uglify": "~0.2.7",
     "grunt-mocha": "^0.4.11",
     "grunt-mocha-test": "^0.12.0",
-    "httpsync": "0.0.8",
     "nock": "^0.48.0",
     "sinon": "^1.10.3"
   }

--- a/cdap-authentication-clients/javascript/src/authmanager.js
+++ b/cdap-authentication-clients/javascript/src/authmanager.js
@@ -48,6 +48,7 @@
             },
             httpConnection = null,
             authUrls = null,
+            authEnabled = null,
             helpers = null,
             AUTH_HEADER_NAME = 'Authorization',
             AUTH_TYPE = 'Basic',
@@ -78,17 +79,23 @@
                 return authUrls[Math.floor(Math.random() * authUrls.length)];
             },
             isAuthEnabledImpl = function () {
-                if (!authUrls) {
-                    authUrls = fetchAuthUrl();
+                if (null == authEnabled) {
+                    if (!authUrls) {
+                        authUrls = fetchAuthUrl();
+                    }
+
+                    authEnabled = !!authUrls;
                 }
 
-                return !!authUrls;
+                return authEnabled;
             },
             fetchToken = helpers.fetchTokenInfo.bind(this, getAuthUrl, httpConnection, getAuthHeaders,
                 AUTH_HEADER_NAME),
             getTokenImpl = function () {
-                if ((TOKEN_EXPIRATION_TIMEOUT >= (tokenInfo.expirationDate - Date.now()))) {
-                    tokenInfo = fetchToken();
+                if (authEnabled) {
+                    if ((TOKEN_EXPIRATION_TIMEOUT >= (tokenInfo.expirationDate - Date.now()))) {
+                        tokenInfo = fetchToken();
+                    }
                 }
 
                 return {

--- a/cdap-authentication-clients/javascript/src/authmanager.js
+++ b/cdap-authentication-clients/javascript/src/authmanager.js
@@ -1,0 +1,123 @@
+/**
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+(function (factory) {
+    'use strict';
+
+    // Support three module loading scenarios
+    if (typeof require === 'function' && typeof exports === 'object' && typeof module === 'object') {
+        // [1] CommonJS/Node.js
+        var target = module['exports'] || exports; // module.exports is for Node.js
+        factory(target, require);
+    } else if (typeof define === 'function' && define['amd']) {
+        // [2] AMD anonymous module
+        define(['exports', 'Promise'], factory);
+    } else {
+        // [3] No module loader (plain <script> tag) - put directly in global namespace
+        factory(window);
+    }
+}(function (target, require) {
+    'use strict';
+
+    var moduleConstructor = function (username, password, hostname, port, ssl) {
+        if (!username || !password) {
+            throw new Error('"username" and "password" have to be defined');
+        }
+
+        var connectionInfo = {
+                host: hostname || 'localhost',
+                port: port || 10000,
+                ssl: (null != ssl) ? ssl : false,
+                user: username,
+                pass: password
+            },
+            tokenInfo = {
+                value: '',
+                type: '',
+                expirationDate: 0
+            },
+            httpConnection = null,
+            authUrls = null,
+            helpers = null,
+            AUTH_HEADER_NAME = 'Authentication',
+            AUTH_TYPE = 'Basic',
+            TOKEN_EXPIRATION_TIMEOUT = 5000;
+
+        if ('undefined' !== typeof window) {
+            helpers = CDAPAuthHelpers.Browser;
+            httpConnection = new XMLHttpRequest();
+        } else {
+            helpers = require('./helper-node');
+            httpConnection = require('httpsync');
+        }
+
+        var getAuthHeaders = helpers.getAuthHeaders.bind(this, AUTH_HEADER_NAME, AUTH_TYPE, connectionInfo),
+            baseUrl = function () {
+                return [
+                    connectionInfo.ssl ? 'https' : 'http',
+                    '://', connectionInfo.host,
+                    ':', connectionInfo.port, '/'
+                ].join('');
+            },
+            fetchAuthUrl = helpers.fetchAuthUrl.bind(this, httpConnection, baseUrl()),
+            getAuthUrl = function () {
+                var authUrl;
+
+                if (!authUrls) {
+                    return '';
+                }
+
+                if (1 === authUrls.length) {
+                    authUrl = authUrls[0];
+                } else {
+                    authUrl = authUrls[Math.floor(Math.random() * (authUrls.length - 1)) + 1];
+                }
+
+                return authUrl;
+            },
+            isAuthEnabledImpl = function () {
+                if (!authUrls) {
+                    authUrls = fetchAuthUrl();
+                }
+
+                return !!authUrls;
+            },
+            fetchToken = helpers.fetchTokenInfo.bind(this, getAuthUrl, httpConnection, getAuthHeaders,
+                AUTH_HEADER_NAME),
+            getTokenImpl = function () {
+                if ((TOKEN_EXPIRATION_TIMEOUT >= (tokenInfo.expirationDate - Date.now()))) {
+                    tokenInfo = fetchToken();
+                }
+
+                return {
+                    token: tokenInfo.value,
+                    type: tokenInfo.type
+                };
+            };
+
+        return {
+            isAuthEnabled: isAuthEnabledImpl,
+            getToken: getTokenImpl
+        };
+    };
+
+    if (('undefined' !== typeof module) && module.exports) {
+        module.exports = moduleConstructor;
+    } else {
+        target['CASKAuthManager'] = target['CASKAuthManager'] || moduleConstructor;
+    }
+}));

--- a/cdap-authentication-clients/javascript/src/authmanager.js
+++ b/cdap-authentication-clients/javascript/src/authmanager.js
@@ -92,7 +92,7 @@
             fetchToken = helpers.fetchTokenInfo.bind(this, getAuthUrl, httpConnection, getAuthHeaders,
                 AUTH_HEADER_NAME),
             getTokenImpl = function () {
-                if (authEnabled) {
+                if (isAuthEnabledImpl()) {
                     if ((TOKEN_EXPIRATION_TIMEOUT >= (tokenInfo.expirationDate - Date.now()))) {
                         tokenInfo = fetchToken();
                     }

--- a/cdap-authentication-clients/javascript/src/authmanager.js
+++ b/cdap-authentication-clients/javascript/src/authmanager.js
@@ -62,7 +62,7 @@
             httpConnection = new XMLHttpRequest();
         } else {
             helpers = require('./helper-node');
-            httpConnection = require('httpsync');
+            httpConnection = require('http-sync');
         }
 
         var getAuthHeaders = helpers.getAuthHeaders.bind(this, AUTH_HEADER_NAME, AUTH_TYPE, connectionInfo),

--- a/cdap-authentication-clients/javascript/src/authmanager.js
+++ b/cdap-authentication-clients/javascript/src/authmanager.js
@@ -33,17 +33,13 @@
 }(function (target, require) {
     'use strict';
 
-    var moduleConstructor = function (username, password, hostname, port, ssl) {
-        if (!username || !password) {
-            throw new Error('"username" and "password" have to be defined');
-        }
-
+    var moduleConstructor = function () {
         var connectionInfo = {
-                host: hostname || 'localhost',
-                port: port || 10000,
-                ssl: (null != ssl) ? ssl : false,
-                user: username,
-                pass: password
+                host: 'localhost',
+                port: 10000,
+                ssl: false,
+                user: '',
+                pass: ''
             },
             tokenInfo = {
                 value: '',
@@ -53,7 +49,7 @@
             httpConnection = null,
             authUrls = null,
             helpers = null,
-            AUTH_HEADER_NAME = 'Authentication',
+            AUTH_HEADER_NAME = 'Authorization',
             AUTH_TYPE = 'Basic',
             TOKEN_EXPIRATION_TIMEOUT = 5000;
 
@@ -73,21 +69,13 @@
                     ':', connectionInfo.port, '/'
                 ].join('');
             },
-            fetchAuthUrl = helpers.fetchAuthUrl.bind(this, httpConnection, baseUrl()),
+            fetchAuthUrl = helpers.fetchAuthUrl.bind(this, httpConnection, baseUrl),
             getAuthUrl = function () {
-                var authUrl;
-
                 if (!authUrls) {
                     return '';
                 }
 
-                if (1 === authUrls.length) {
-                    authUrl = authUrls[0];
-                } else {
-                    authUrl = authUrls[Math.floor(Math.random() * (authUrls.length - 1)) + 1];
-                }
-
-                return authUrl;
+                return authUrls[Math.floor(Math.random() * authUrls.length)];
             },
             isAuthEnabledImpl = function () {
                 if (!authUrls) {
@@ -107,11 +95,36 @@
                     token: tokenInfo.value,
                     type: tokenInfo.type
                 };
+            },
+            /**
+             * @param {Object} properties {
+             *   @param {string} username,
+             *   @param {password} password
+             * }
+             */
+            configureImpl = function (properties) {
+                if (!properties.username || !properties.password) {
+                    throw new Error('"username" and "password" are required');
+                }
+
+                if (connectionInfo.user && connectionInfo.pass) {
+                    throw new Error('Client is already configured!');
+                }
+
+                connectionInfo.user = properties.username;
+                connectionInfo.pass = properties.password;
+            },
+            setConnectionInfoImpl = function (host, port, ssl) {
+                connectionInfo.host = host;
+                connectionInfo.port = port;
+                connectionInfo.ssl = ssl;
             };
 
         return {
             isAuthEnabled: isAuthEnabledImpl,
-            getToken: getTokenImpl
+            getToken: getTokenImpl,
+            configure: configureImpl,
+            setConnectionInfo: setConnectionInfoImpl
         };
     };
 

--- a/cdap-authentication-clients/javascript/src/authmanager.js
+++ b/cdap-authentication-clients/javascript/src/authmanager.js
@@ -25,7 +25,7 @@
         factory(target, require);
     } else if (typeof define === 'function' && define['amd']) {
         // [2] AMD anonymous module
-        define(['exports', 'Promise'], factory);
+        define(['exports', 'CDAPAuthManager'], factory);
     } else {
         // [3] No module loader (plain <script> tag) - put directly in global namespace
         factory(window);
@@ -125,19 +125,40 @@
                 connectionInfo.host = host;
                 connectionInfo.port = port;
                 connectionInfo.ssl = ssl;
+            },
+            invalidateTokenImpl = function () {
+                tokenInfo.value = '';
+                tokenInfo.type = '';
+                tokenInfo.expirationDate = 0;
+            },
+            getRequiredCredentialsImpl = function () {
+                return [
+                    {
+                        name: 'username',
+                        description: 'Username for basic authentication.',
+                        secret: false
+                    },
+                    {
+                        name: 'password',
+                        description: 'Password for basic authentication.',
+                        secret: true
+                    }
+                ];
             };
 
         return {
             isAuthEnabled: isAuthEnabledImpl,
             getToken: getTokenImpl,
             configure: configureImpl,
-            setConnectionInfo: setConnectionInfoImpl
+            setConnectionInfo: setConnectionInfoImpl,
+            invalidateToken: invalidateTokenImpl,
+            getRequiredCredentials: getRequiredCredentialsImpl
         };
     };
 
     if (('undefined' !== typeof module) && module.exports) {
         module.exports = moduleConstructor;
     } else {
-        target['CASKAuthManager'] = target['CASKAuthManager'] || moduleConstructor;
+        target['CDAPAuthManager'] = target['CDAPAuthManager'] || moduleConstructor;
     }
 }));

--- a/cdap-authentication-clients/javascript/src/base64.js
+++ b/cdap-authentication-clients/javascript/src/base64.js
@@ -1,0 +1,142 @@
+/**
+ *
+ *  Base64 encode / decode
+ *  http://www.webtoolkit.info/
+ *
+ **/
+
+var Base64 = {
+
+    // private property
+    _keyStr : "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=",
+
+    // public method for encoding
+    encode : function (input) {
+        var output = "";
+        var chr1, chr2, chr3, enc1, enc2, enc3, enc4;
+        var i = 0;
+
+        input = Base64._utf8_encode(input);
+
+        while (i < input.length) {
+
+            chr1 = input.charCodeAt(i++);
+            chr2 = input.charCodeAt(i++);
+            chr3 = input.charCodeAt(i++);
+
+            enc1 = chr1 >> 2;
+            enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
+            enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
+            enc4 = chr3 & 63;
+
+            if (isNaN(chr2)) {
+                enc3 = enc4 = 64;
+            } else if (isNaN(chr3)) {
+                enc4 = 64;
+            }
+
+            output = output +
+                this._keyStr.charAt(enc1) + this._keyStr.charAt(enc2) +
+                this._keyStr.charAt(enc3) + this._keyStr.charAt(enc4);
+
+        }
+
+        return output;
+    },
+
+    // public method for decoding
+    decode : function (input) {
+        var output = "";
+        var chr1, chr2, chr3;
+        var enc1, enc2, enc3, enc4;
+        var i = 0;
+
+        input = input.replace(/[^A-Za-z0-9\+\/\=]/g, "");
+
+        while (i < input.length) {
+
+            enc1 = this._keyStr.indexOf(input.charAt(i++));
+            enc2 = this._keyStr.indexOf(input.charAt(i++));
+            enc3 = this._keyStr.indexOf(input.charAt(i++));
+            enc4 = this._keyStr.indexOf(input.charAt(i++));
+
+            chr1 = (enc1 << 2) | (enc2 >> 4);
+            chr2 = ((enc2 & 15) << 4) | (enc3 >> 2);
+            chr3 = ((enc3 & 3) << 6) | enc4;
+
+            output = output + String.fromCharCode(chr1);
+
+            if (enc3 != 64) {
+                output = output + String.fromCharCode(chr2);
+            }
+            if (enc4 != 64) {
+                output = output + String.fromCharCode(chr3);
+            }
+
+        }
+
+        output = Base64._utf8_decode(output);
+
+        return output;
+
+    },
+
+    // private method for UTF-8 encoding
+    _utf8_encode : function (string) {
+        string = string.replace(/\r\n/g,"\n");
+        var utftext = "";
+
+        for (var n = 0; n < string.length; n++) {
+
+            var c = string.charCodeAt(n);
+
+            if (c < 128) {
+                utftext += String.fromCharCode(c);
+            }
+            else if((c > 127) && (c < 2048)) {
+                utftext += String.fromCharCode((c >> 6) | 192);
+                utftext += String.fromCharCode((c & 63) | 128);
+            }
+            else {
+                utftext += String.fromCharCode((c >> 12) | 224);
+                utftext += String.fromCharCode(((c >> 6) & 63) | 128);
+                utftext += String.fromCharCode((c & 63) | 128);
+            }
+
+        }
+
+        return utftext;
+    },
+
+    // private method for UTF-8 decoding
+    _utf8_decode : function (utftext) {
+        var string = "";
+        var i = 0;
+        var c = c1 = c2 = 0;
+
+        while ( i < utftext.length ) {
+
+            c = utftext.charCodeAt(i);
+
+            if (c < 128) {
+                string += String.fromCharCode(c);
+                i++;
+            }
+            else if((c > 191) && (c < 224)) {
+                c2 = utftext.charCodeAt(i+1);
+                string += String.fromCharCode(((c & 31) << 6) | (c2 & 63));
+                i += 2;
+            }
+            else {
+                c2 = utftext.charCodeAt(i+1);
+                c3 = utftext.charCodeAt(i+2);
+                string += String.fromCharCode(((c & 15) << 12) | ((c2 & 63) << 6) | (c3 & 63));
+                i += 3;
+            }
+
+        }
+
+        return string;
+    }
+
+}

--- a/cdap-authentication-clients/javascript/src/helper-browser.js
+++ b/cdap-authentication-clients/javascript/src/helper-browser.js
@@ -27,7 +27,7 @@ window.CDAPAuthHelpers.Browser = {
         return obj;
     },
     fetchAuthUrl: function (httpConnection, baseUrl) {
-        httpConnection.open('GET', baseUrl(), false);
+        httpConnection.open('GET', baseUrl() + '/v2/ping', false);
         httpConnection.send();
 
         var authUrls = null;

--- a/cdap-authentication-clients/javascript/src/helper-browser.js
+++ b/cdap-authentication-clients/javascript/src/helper-browser.js
@@ -27,7 +27,7 @@ window.CDAPAuthHelpers.Browser = {
         return obj;
     },
     fetchAuthUrl: function (httpConnection, baseUrl) {
-        httpConnection.open('GET', baseUrl, false);
+        httpConnection.open('GET', baseUrl(), false);
         httpConnection.send();
 
         var authUrls = null;

--- a/cdap-authentication-clients/javascript/src/helper-browser.js
+++ b/cdap-authentication-clients/javascript/src/helper-browser.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+window.CDAPAuthHelpers = window.CDAPAuthHelpers || {};
+
+window.CDAPAuthHelpers.Browser = {
+    getAuthHeaders: function (headerName, authType, connectionInfo) {
+        var obj = {};
+
+        obj[headerName] = authType + ' ' + Base64.encode(
+                connectionInfo.user + ':' + connectionInfo.pass
+        );
+
+        return obj;
+    },
+    fetchAuthUrl: function (httpConnection, baseUrl) {
+        httpConnection.open('GET', baseUrl, false);
+        httpConnection.send();
+
+        var authUrls = null;
+        if (XMLHttpRequest.DONE === httpConnection.readyState && 401 === httpConnection.status) {
+            authUrls = JSON.parse(httpConnection.responseText)['auth_uri'];
+        }
+
+        return authUrls;
+    },
+    fetchTokenInfo: function (authUrl, httpConnection, headers, authHeaderName) {
+        httpConnection.open('GET', authUrl(), false);
+        httpConnection.setRequestHeader(authHeaderName, headers()[authHeaderName]);
+
+        var tokenInfo = {
+            value: '',
+            type: '',
+            expirationDate: 0
+        };
+        if (authUrl) {
+            httpConnection.send();
+
+            if (XMLHttpRequest.DONE === httpConnection.readyState && 200 === httpConnection.status) {
+                var tokenData = JSON.parse(httpConnection.responseText);
+
+                tokenInfo.value = tokenData.access_token;
+                tokenInfo.type = tokenData.token_type;
+                tokenInfo.expirationDate = Date.now() + (tokenData.expires_in * 1000);
+            }
+        }
+
+        return tokenInfo;
+    }
+};

--- a/cdap-authentication-clients/javascript/src/helper-node.js
+++ b/cdap-authentication-clients/javascript/src/helper-node.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+module.exports = {
+    getAuthHeaders: function (headerName, authType, connectionInfo) {
+        var obj = {};
+
+        obj[headerName] = authType + ' ' + new Buffer(
+                connectionInfo.user + ':' + connectionInfo.pass
+        ).toString('base64');
+
+        return obj;
+    },
+    fetchAuthUrl: function (httpConnection, baseUrl) {
+        var authUrls = null,
+            request = httpConnection.request({
+                url: baseUrl,
+                method: 'GET'
+            }),
+            response = request.end();
+
+        if (401 === response.status) {
+            authUrls = JSON.parse(response.data)['auth_uri'];
+        }
+
+        return authUrls;
+    },
+    fetchTokenInfo: function (authUrl, httpConnection, headers) {
+        var tokenInfo = {},
+            __authUrl = authUrl();
+
+        if (__authUrl) {
+            var request = httpConnection.request({
+                    url: __authUrl,
+                    method: 'GET',
+                    headers: headers()
+                }),
+                response = request.end();
+
+            if (200 === response.status) {
+                var tokenData = JSON.parse(response.data);
+
+                tokenInfo.value = tokenData.access_token;
+                tokenInfo.type = tokenData.token_type;
+                tokenInfo.expirationDate = Date.now() + (tokenData.expires_in * 1000);
+            }
+        }
+
+        return tokenInfo;
+    }
+};

--- a/cdap-authentication-clients/javascript/src/helper-node.js
+++ b/cdap-authentication-clients/javascript/src/helper-node.js
@@ -33,7 +33,7 @@ module.exports = {
                 protocol: parsedUrl.protocol,
                 host: parsedUrl.hostname,
                 port: parsedUrl.port,
-                path: parsedUrl.pathname + '/v2/ping',
+                path: '/v2/ping',
                 method: 'GET'
             }),
             response = request.end();

--- a/cdap-authentication-clients/javascript/src/helper-node.js
+++ b/cdap-authentication-clients/javascript/src/helper-node.js
@@ -25,38 +25,43 @@ module.exports = {
         return obj;
     },
     fetchAuthUrl: function (httpConnection, baseUrl) {
-        var authUrls = null,
+        var parsedUrl = url.parse(baseUrl()),
+            authUrls = null,
             request = httpConnection.request({
-                url: baseUrl,
+                protocol: parsedUrl.protocol,
+                host: parsedUrl.hostname,
+                port: parsedUrl.port,
+                path: parsedUrl.pathname,
                 method: 'GET'
             }),
             response = request.end();
 
-        if (401 === response.status) {
-            authUrls = JSON.parse(response.data)['auth_uri'];
+        if (401 === response.statusCode) {
+            authUrls = JSON.parse(response.body)['auth_uri'];
         }
 
         return authUrls;
     },
     fetchTokenInfo: function (authUrl, httpConnection, headers) {
         var tokenInfo = {},
-            __authUrl = authUrl();
+            parsedUrl = url.parse(authUrl());
 
-        if (__authUrl) {
-            var request = httpConnection.request({
-                    url: __authUrl,
-                    method: 'GET',
-                    headers: headers()
-                }),
-                response = request.end();
+        var request = httpConnection.request({
+                protocol: parsedUrl.protocol,
+                host: parsedUrl.hostname,
+                port: parsedUrl.port,
+                path: parsedUrl.pathname,
+                method: 'GET',
+                headers: headers()
+            }),
+            response = request.end();
 
-            if (200 === response.status) {
-                var tokenData = JSON.parse(response.data);
+        if (200 === response.statusCode) {
+            var tokenData = JSON.parse(response.body);
 
-                tokenInfo.value = tokenData.access_token;
-                tokenInfo.type = tokenData.token_type;
-                tokenInfo.expirationDate = Date.now() + (tokenData.expires_in * 1000);
-            }
+            tokenInfo.value = tokenData.access_token;
+            tokenInfo.type = tokenData.token_type;
+            tokenInfo.expirationDate = Date.now() + (tokenData.expires_in * 1000);
         }
 
         return tokenInfo;

--- a/cdap-authentication-clients/javascript/src/helper-node.js
+++ b/cdap-authentication-clients/javascript/src/helper-node.js
@@ -14,6 +14,8 @@
  * the License.
  */
 
+var Url = require('url');
+
 module.exports = {
     getAuthHeaders: function (headerName, authType, connectionInfo) {
         var obj = {};
@@ -25,7 +27,7 @@ module.exports = {
         return obj;
     },
     fetchAuthUrl: function (httpConnection, baseUrl) {
-        var parsedUrl = url.parse(baseUrl()),
+        var parsedUrl = Url.parse(baseUrl()),
             authUrls = null,
             request = httpConnection.request({
                 protocol: parsedUrl.protocol,
@@ -44,7 +46,7 @@ module.exports = {
     },
     fetchTokenInfo: function (authUrl, httpConnection, headers) {
         var tokenInfo = {},
-            parsedUrl = url.parse(authUrl());
+            parsedUrl = Url.parse(authUrl());
 
         var request = httpConnection.request({
                 protocol: parsedUrl.protocol,

--- a/cdap-authentication-clients/javascript/src/helper-node.js
+++ b/cdap-authentication-clients/javascript/src/helper-node.js
@@ -33,7 +33,7 @@ module.exports = {
                 protocol: parsedUrl.protocol,
                 host: parsedUrl.hostname,
                 port: parsedUrl.port,
-                path: parsedUrl.pathname,
+                path: parsedUrl.pathname + '/v2/ping',
                 method: 'GET'
             }),
             response = request.end();

--- a/cdap-authentication-clients/javascript/src/nodejs/package.json
+++ b/cdap-authentication-clients/javascript/src/nodejs/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "cdap-auth-client",
+    "version": "1.0.0",
+    "main": "authmanager.js",
+    "dependencies": {
+        "httpsync": "0.0.8"
+    }
+}

--- a/cdap-authentication-clients/javascript/src/nodejs/package.json
+++ b/cdap-authentication-clients/javascript/src/nodejs/package.json
@@ -3,6 +3,6 @@
     "version": "1.0.0",
     "main": "authmanager.js",
     "dependencies": {
-        "httpsync": "0.0.8"
+        "http-sync": "0.0.5"
     }
 }

--- a/cdap-authentication-clients/javascript/test/authmanager-browser.js
+++ b/cdap-authentication-clients/javascript/test/authmanager-browser.js
@@ -12,16 +12,19 @@ describe('CDAP Auth manager tests', function () {
 
     describe('Checking Auth Manager functionality', function () {
         it('Constructor creates correct object', function () {
-            var authManager = new CASKAuthManager('username', 'password');
+            var authManager = new CASKAuthManager();
+
+            authManager.configure({username: 'username', password: 'password'});
 
             expect(authManager).to.be.an('object');
             expect(authManager).to.have.property('isAuthEnabled');
             expect(authManager).to.have.property('getToken');
         });
 
-        it('Constructor could not be called without "username" or "password" field', function () {
+        it('"configure" method could not be called without "username" or "password" field', function () {
+            var authManager = new CASKAuthManager();
             expect(function () {
-                var authManager = new CASKAuthManager();
+                authManager.configure({});
             }).to.throwException(function (e) {
                     expect(e).to.be.an(Error);
                 });
@@ -30,8 +33,11 @@ describe('CDAP Auth manager tests', function () {
         it('Authentication is disabled on server side.', function () {
             this.server.respondWith([200, {'Content-Type': 'application/json'}, '']);
 
-            var authManager = new CASKAuthManager('username', 'password'),
-                authEnabled = authManager.isAuthEnabled();
+            var authManager = new CASKAuthManager(),
+                authEnabled = false;
+
+            authManager.configure({username: 'username', password: 'password'});
+            authEnabled = authManager.isAuthEnabled();
 
             expect(authEnabled).to.not.be.ok();
         });
@@ -43,8 +49,11 @@ describe('CDAP Auth manager tests', function () {
 
             this.server.respondWith([401, {'Content-Type': 'application/json'}, JSON.stringify(jsonResp)]);
 
-            var authManager = new CASKAuthManager('username', 'password'),
-                authEnabled = authManager.isAuthEnabled();
+            var authManager = new CASKAuthManager(),
+                authEnabled = false;
+
+            authManager.configure({username: 'username', password: 'password'});
+            authEnabled = authManager.isAuthEnabled();
 
             expect(authEnabled).to.be.ok();
         });
@@ -58,8 +67,11 @@ describe('CDAP Auth manager tests', function () {
 
             this.server.respondWith([200, {'Content-Type': 'application/json'}, JSON.stringify(jsonResp)]);
 
-            var authManager = new CASKAuthManager('username', 'password'),
-                authToken = authManager.getToken();
+            var authManager = new CASKAuthManager(),
+                authToken = '';
+
+            authManager.configure({username: 'username', password: 'password'});
+            authToken = authManager.getToken();
 
             expect(authToken).to.have.property('token');
             expect(authToken).to.have.property('type');
@@ -79,8 +91,10 @@ describe('CDAP Auth manager tests', function () {
             this.server.respondWith(/\/token\/url[1-9]*$/, [200, {'Content-Type': 'application/json'},
                 JSON.stringify(jsonResp2)]);
 
-            var authManager = new CASKAuthManager('username', 'password'),
+            var authManager = new CASKAuthManager(),
                 authToken;
+
+            authManager.configure({username: 'username', password: 'password'});
 
             if (authManager.isAuthEnabled()) {
                 authToken = authManager.getToken();

--- a/cdap-authentication-clients/javascript/test/authmanager-browser.js
+++ b/cdap-authentication-clients/javascript/test/authmanager-browser.js
@@ -19,6 +19,10 @@ describe('CDAP Auth manager tests', function () {
             expect(authManager).to.be.an('object');
             expect(authManager).to.have.property('isAuthEnabled');
             expect(authManager).to.have.property('getToken');
+            expect(authManager).to.have.property('configure');
+            expect(authManager).to.have.property('setConnectionInfo');
+            expect(authManager).to.have.property('getRequiredCredentials');
+            expect(authManager).to.have.property('invalidateToken');
         });
 
         it('"configure" method could not be called without "username" or "password" field', function () {

--- a/cdap-authentication-clients/javascript/test/authmanager-browser.js
+++ b/cdap-authentication-clients/javascript/test/authmanager-browser.js
@@ -1,0 +1,93 @@
+describe('CDAP Auth manager tests', function () {
+    beforeEach(function () {
+        /*        sinon.log = function (data) {
+         console.log(data);
+         };*/
+        this.server = sinon.fakeServer.create();
+    });
+
+    afterEach(function () {
+        this.server.restore();
+    });
+
+    describe('Checking Auth Manager functionality', function () {
+        it('Constructor creates correct object', function () {
+            var authManager = new CASKAuthManager('username', 'password');
+
+            expect(authManager).to.be.an('object');
+            expect(authManager).to.have.property('isAuthEnabled');
+            expect(authManager).to.have.property('getToken');
+        });
+
+        it('Constructor could not be called without "username" or "password" field', function () {
+            expect(function () {
+                var authManager = new CASKAuthManager();
+            }).to.throwException(function (e) {
+                    expect(e).to.be.an(Error);
+                });
+        });
+
+        it('Authentication is disabled on server side.', function () {
+            this.server.respondWith([200, {'Content-Type': 'application/json'}, '']);
+
+            var authManager = new CASKAuthManager('username', 'password'),
+                authEnabled = authManager.isAuthEnabled();
+
+            expect(authEnabled).to.not.be.ok();
+        });
+
+        it('Authentication is enabled on server side.', function () {
+            var jsonResp = {
+                auth_uri: ["/some/url", "/some/url1", "/some/url2"]
+            };
+
+            this.server.respondWith([401, {'Content-Type': 'application/json'}, JSON.stringify(jsonResp)]);
+
+            var authManager = new CASKAuthManager('username', 'password'),
+                authEnabled = authManager.isAuthEnabled();
+
+            expect(authEnabled).to.be.ok();
+        });
+
+        it('"getToken" returns valid object', function () {
+            var jsonResp = {
+                "access_token": "2YotnFZFEjr1zCsicMWpAA",
+                "token_type": "Bearer",
+                "expires_in": 3600
+            };
+
+            this.server.respondWith([200, {'Content-Type': 'application/json'}, JSON.stringify(jsonResp)]);
+
+            var authManager = new CASKAuthManager('username', 'password'),
+                authToken = authManager.getToken();
+
+            expect(authToken).to.have.property('token');
+            expect(authToken).to.have.property('type');
+        });
+
+        it('"getToken" returns valid token data', function () {
+            var jsonResp1 = {
+                    auth_uri: ["/token/url", "/token/url1", "/token/url2"]
+                },
+                jsonResp2 = {
+                    access_token: "2YotnFZFEjr1zCsicMWpAA",
+                    token_type: "Bearer",
+                    expires_in: 3600
+                };
+
+            this.server.respondWith(/\/$/, [401, {'Content-Type': 'application/json'}, JSON.stringify(jsonResp1)]);
+            this.server.respondWith(/\/token\/url[1-9]*$/, [200, {'Content-Type': 'application/json'},
+                JSON.stringify(jsonResp2)]);
+
+            var authManager = new CASKAuthManager('username', 'password'),
+                authToken;
+
+            if (authManager.isAuthEnabled()) {
+                authToken = authManager.getToken();
+            }
+
+            expect(authToken.token).to.be(jsonResp2.access_token);
+            expect(authToken.type).to.be(jsonResp2.token_type);
+        });
+    });
+});

--- a/cdap-authentication-clients/javascript/test/authmanager-browser.js
+++ b/cdap-authentication-clients/javascript/test/authmanager-browser.js
@@ -12,7 +12,7 @@ describe('CDAP Auth manager tests', function () {
 
     describe('Checking Auth Manager functionality', function () {
         it('Constructor creates correct object', function () {
-            var authManager = new CASKAuthManager();
+            var authManager = new CDAPAuthManager();
 
             authManager.configure({username: 'username', password: 'password'});
 
@@ -26,7 +26,7 @@ describe('CDAP Auth manager tests', function () {
         });
 
         it('"configure" method could not be called without "username" or "password" field', function () {
-            var authManager = new CASKAuthManager();
+            var authManager = new CDAPAuthManager();
             expect(function () {
                 authManager.configure({});
             }).to.throwException(function (e) {
@@ -37,7 +37,7 @@ describe('CDAP Auth manager tests', function () {
         it('Authentication is disabled on server side.', function () {
             this.server.respondWith([200, {'Content-Type': 'application/json'}, '']);
 
-            var authManager = new CASKAuthManager(),
+            var authManager = new CDAPAuthManager(),
                 authEnabled = false;
 
             authManager.configure({username: 'username', password: 'password'});
@@ -53,7 +53,7 @@ describe('CDAP Auth manager tests', function () {
 
             this.server.respondWith([401, {'Content-Type': 'application/json'}, JSON.stringify(jsonResp)]);
 
-            var authManager = new CASKAuthManager(),
+            var authManager = new CDAPAuthManager(),
                 authEnabled = false;
 
             authManager.configure({username: 'username', password: 'password'});
@@ -71,7 +71,7 @@ describe('CDAP Auth manager tests', function () {
 
             this.server.respondWith([200, {'Content-Type': 'application/json'}, JSON.stringify(jsonResp)]);
 
-            var authManager = new CASKAuthManager(),
+            var authManager = new CDAPAuthManager(),
                 authToken = '';
 
             authManager.configure({username: 'username', password: 'password'});
@@ -82,30 +82,28 @@ describe('CDAP Auth manager tests', function () {
         });
 
         it('"getToken" returns valid token data', function () {
-            var jsonResp1 = {
+            var jsonRespAuthUrls = {
                     auth_uri: ["/token/url", "/token/url1", "/token/url2"]
                 },
-                jsonResp2 = {
+                jsonRespAuthToken = {
                     access_token: "2YotnFZFEjr1zCsicMWpAA",
                     token_type: "Bearer",
                     expires_in: 3600
                 };
 
-            this.server.respondWith(/\/$/, [401, {'Content-Type': 'application/json'}, JSON.stringify(jsonResp1)]);
+            this.server.respondWith(/\/v2\/ping$/, [401, {'Content-Type': 'application/json'}, JSON.stringify(jsonRespAuthUrls)]);
             this.server.respondWith(/\/token\/url[1-9]*$/, [200, {'Content-Type': 'application/json'},
-                JSON.stringify(jsonResp2)]);
+                JSON.stringify(jsonRespAuthToken)]);
 
-            var authManager = new CASKAuthManager(),
+            var authManager = new CDAPAuthManager(),
                 authToken;
 
             authManager.configure({username: 'username', password: 'password'});
 
-            if (authManager.isAuthEnabled()) {
-                authToken = authManager.getToken();
-            }
+            authToken = authManager.getToken();
 
-            expect(authToken.token).to.be(jsonResp2.access_token);
-            expect(authToken.type).to.be(jsonResp2.token_type);
+            expect(authToken.token).to.be(jsonRespAuthToken.access_token);
+            expect(authToken.type).to.be(jsonRespAuthToken.token_type);
         });
     });
 });

--- a/cdap-authentication-clients/javascript/test/authmanager-spec.js
+++ b/cdap-authentication-clients/javascript/test/authmanager-spec.js
@@ -1,7 +1,7 @@
 var CDAPAuthManager = require('../src/authmanager'),
     expect = require('expect.js'),
     sinon = require('sinon'),
-    httpsync = require('httpsync');
+    httpsync = require('http-sync');
 
 describe('CDAP Auth manager tests', function () {
     describe('Checking Auth Manager functionality', function () {

--- a/cdap-authentication-clients/javascript/test/authmanager-spec.js
+++ b/cdap-authentication-clients/javascript/test/authmanager-spec.js
@@ -90,7 +90,7 @@ describe('CDAP Auth manager tests', function () {
                     host: "localhost",
                     port: "10000",
                     protocol: "http:",
-                    path: '/',
+                    path: '/v2/ping',
                     method: 'GET'
                 },
                 fetchTokenArgs = {
@@ -154,7 +154,7 @@ describe('CDAP Auth manager tests', function () {
                     host: "localhost",
                     port: "10000",
                     protocol: "http:",
-                    path: '/',
+                    path: '/v2/ping',
                     method: 'GET'
                 },
                 fetchTokenArgs = {

--- a/cdap-authentication-clients/javascript/test/authmanager-spec.js
+++ b/cdap-authentication-clients/javascript/test/authmanager-spec.js
@@ -1,0 +1,178 @@
+var CDAPAuthManager = require('../src/authmanager'),
+    expect = require('expect.js'),
+    sinon = require('sinon'),
+    httpsync = require('httpsync');
+
+describe('CDAP Auth manager tests', function () {
+    describe('Checking Auth Manager functionality', function () {
+        it('Constructor creates correct object', function () {
+            var authManager = new CDAPAuthManager('username', 'password');
+
+            expect(authManager).to.be.an('object');
+            expect(authManager).to.have.property('isAuthEnabled');
+            expect(authManager).to.have.property('getToken');
+        });
+
+        it('Constructor could not be called without "username" or "password" field', function () {
+            expect(function () {
+                var authManager = new CDAPAuthManager();
+            }).to.throwException(function (e) {
+                    expect(e).to.be.an(Error);
+                });
+        });
+
+        it('Authentication is disabled on server side.', function () {
+            var mock = sinon.mock(httpsync);
+            mock.expects('request').once().returns({
+                end: function () {
+                    return {
+                        status: 200,
+                        data: ''
+                    };
+                }
+            });
+
+            var authManager = new CDAPAuthManager('username', 'password'),
+                authEnabled = authManager.isAuthEnabled();
+
+            mock.verify();
+            mock.restore();
+
+            expect(authEnabled).to.not.be.ok();
+        });
+
+        it('Authentication is enabled on server side.', function () {
+            var jsonResp = {
+                    auth_uri: ["/some/url", "/some/url1", "/some/url2"]
+                },
+                mock = sinon.mock(httpsync);
+
+            mock.expects('request').once().returns({
+                end: function () {
+                    return {
+                        status: 401,
+                        data: JSON.stringify(jsonResp)
+                    };
+                }
+            });
+
+            var authManager = new CDAPAuthManager('username', 'password'),
+                authEnabled = authManager.isAuthEnabled();
+
+            mock.verify();
+            mock.restore();
+
+            expect(authEnabled).to.be.ok();
+        });
+
+        it('"getToken" returns valid object', function () {
+            var username = 'username',
+                password = 'password',
+                jsonResp1 = {
+                    auth_uri: ["/token/url"]
+                },
+                jsonResp2 = {
+                    "access_token": "2YotnFZFEjr1zCsicMWpAA",
+                    "token_type": "Bearer",
+                    "expires_in": 3600
+                },
+                mock = sinon.mock(httpsync),
+                getAuthUrlArgs = {
+                    url: 'http://localhost:10000/',
+                    method: 'GET'
+                },
+                fetchTokenArgs = {
+                    url: '/token/url',
+                    method: 'GET',
+                    headers: {
+                        Authentication: 'Basic ' + new Buffer(username + ':' + password).toString('base64')
+                    }
+                };
+
+            mock.expects('request').withArgs(getAuthUrlArgs).returns({
+                end: function () {
+                    return {
+                        status: 401,
+                        data: JSON.stringify(jsonResp1)
+                    };
+                }
+            });
+            mock.expects('request').withArgs(fetchTokenArgs).returns({
+                end: function () {
+                    return {
+                        status: 200,
+                        data: JSON.stringify(jsonResp2)
+                    };
+                }
+            });
+
+            var authManager = new CDAPAuthManager(username, password),
+                authToken;
+
+            if (authManager.isAuthEnabled()) {
+                authToken = authManager.getToken();
+            }
+
+            mock.verify();
+            mock.restore();
+
+            expect(authToken).to.have.property('token');
+            expect(authToken).to.have.property('type');
+        });
+
+        it('"getToken" returns valid token data', function () {
+            var username = 'username',
+                password = 'password',
+                jsonResp1 = {
+                    auth_uri: ["/token/url"]
+                },
+                jsonResp2 = {
+                    access_token: "2YotnFZFEjr1zCsicMWpAA",
+                    token_type: "Bearer",
+                    expires_in: 3600
+                },
+                mock = sinon.mock(httpsync),
+                getAuthUrlArgs = {
+                    url: 'http://localhost:10000/',
+                    method: 'GET'
+                },
+                fetchTokenArgs = {
+                    url: '/token/url',
+                    method: 'GET',
+                    headers: {
+                        Authentication: 'Basic ' + new Buffer(username + ':' + password).toString('base64')
+                    }
+                };
+
+            mock.expects('request').withArgs(getAuthUrlArgs).returns({
+                end: function () {
+                    return {
+                        status: 401,
+                        data: JSON.stringify(jsonResp1)
+                    };
+                }
+            });
+            mock.expects('request').withArgs(fetchTokenArgs).returns({
+                end: function () {
+                    return {
+                        status: 200,
+                        data: JSON.stringify(jsonResp2)
+                    };
+                }
+            });
+
+            var authManager = new CDAPAuthManager(username, password),
+                authToken;
+
+            if (authManager.isAuthEnabled()) {
+                authToken = authManager.getToken();
+            }
+
+            mock.verify();
+            mock.restore();
+
+            expect(authToken.token).to.be(jsonResp2.access_token);
+            expect(authToken.type).to.be(jsonResp2.token_type);
+        });
+    });
+});

--- a/cdap-authentication-clients/javascript/test/authmanager-spec.js
+++ b/cdap-authentication-clients/javascript/test/authmanager-spec.js
@@ -6,16 +6,19 @@ var CDAPAuthManager = require('../src/authmanager'),
 describe('CDAP Auth manager tests', function () {
     describe('Checking Auth Manager functionality', function () {
         it('Constructor creates correct object', function () {
-            var authManager = new CDAPAuthManager('username', 'password');
+            var authManager = new CDAPAuthManager();
 
             expect(authManager).to.be.an('object');
             expect(authManager).to.have.property('isAuthEnabled');
             expect(authManager).to.have.property('getToken');
+            expect(authManager).to.have.property('configure');
+            expect(authManager).to.have.property('setConnectionInfo');
         });
 
-        it('Constructor could not be called without "username" or "password" field', function () {
+        it('"configure" method could not be called without "username" or "password" field', function () {
+            var authManager = new CDAPAuthManager();
             expect(function () {
-                var authManager = new CDAPAuthManager();
+                authManager.configure({});
             }).to.throwException(function (e) {
                     expect(e).to.be.an(Error);
                 });
@@ -26,14 +29,17 @@ describe('CDAP Auth manager tests', function () {
             mock.expects('request').once().returns({
                 end: function () {
                     return {
-                        status: 200,
-                        data: ''
+                        statusCode: 200,
+                        body: ''
                     };
                 }
             });
 
-            var authManager = new CDAPAuthManager('username', 'password'),
-                authEnabled = authManager.isAuthEnabled();
+            var authManager = new CDAPAuthManager(),
+                authEnabled = false;
+
+            authManager.setConnectionInfo('localhost', 10000, false);
+            authEnabled = authManager.isAuthEnabled();
 
             mock.verify();
             mock.restore();
@@ -50,14 +56,17 @@ describe('CDAP Auth manager tests', function () {
             mock.expects('request').once().returns({
                 end: function () {
                     return {
-                        status: 401,
-                        data: JSON.stringify(jsonResp)
+                        statusCode: 401,
+                        body: JSON.stringify(jsonResp)
                     };
                 }
             });
 
-            var authManager = new CDAPAuthManager('username', 'password'),
-                authEnabled = authManager.isAuthEnabled();
+            var authManager = new CDAPAuthManager(),
+                authEnabled = false;
+
+            authManager.setConnectionInfo('localhost', 10000, false);
+            authEnabled = authManager.isAuthEnabled();
 
             mock.verify();
             mock.restore();
@@ -78,36 +87,45 @@ describe('CDAP Auth manager tests', function () {
                 },
                 mock = sinon.mock(httpsync),
                 getAuthUrlArgs = {
-                    url: 'http://localhost:10000/',
+                    host: "localhost",
+                    port: "10000",
+                    protocol: "http:",
+                    path: '/',
                     method: 'GET'
                 },
                 fetchTokenArgs = {
-                    url: '/token/url',
+                    host: null,
+                    port: null,
+                    protocol: null,
+                    path: '/token/url',
                     method: 'GET',
                     headers: {
-                        Authentication: 'Basic ' + new Buffer(username + ':' + password).toString('base64')
+                        Authorization: 'Basic ' + new Buffer(username + ':' + password).toString('base64')
                     }
                 };
 
             mock.expects('request').withArgs(getAuthUrlArgs).returns({
                 end: function () {
                     return {
-                        status: 401,
-                        data: JSON.stringify(jsonResp1)
+                        statusCode: 401,
+                        body: JSON.stringify(jsonResp1)
                     };
                 }
             });
             mock.expects('request').withArgs(fetchTokenArgs).returns({
                 end: function () {
                     return {
-                        status: 200,
-                        data: JSON.stringify(jsonResp2)
+                        statusCode: 200,
+                        body: JSON.stringify(jsonResp2)
                     };
                 }
             });
 
-            var authManager = new CDAPAuthManager(username, password),
+            var authManager = new CDAPAuthManager(),
                 authToken;
+
+            authManager.setConnectionInfo('localhost', 10000, false);
+            authManager.configure({username: username, password: password});
 
             if (authManager.isAuthEnabled()) {
                 authToken = authManager.getToken();
@@ -133,36 +151,45 @@ describe('CDAP Auth manager tests', function () {
                 },
                 mock = sinon.mock(httpsync),
                 getAuthUrlArgs = {
-                    url: 'http://localhost:10000/',
+                    host: "localhost",
+                    port: "10000",
+                    protocol: "http:",
+                    path: '/',
                     method: 'GET'
                 },
                 fetchTokenArgs = {
-                    url: '/token/url',
+                    host: null,
+                    port: null,
+                    protocol: null,
+                    path: '/token/url',
                     method: 'GET',
                     headers: {
-                        Authentication: 'Basic ' + new Buffer(username + ':' + password).toString('base64')
+                        Authorization: 'Basic ' + new Buffer(username + ':' + password).toString('base64')
                     }
                 };
 
             mock.expects('request').withArgs(getAuthUrlArgs).returns({
                 end: function () {
                     return {
-                        status: 401,
-                        data: JSON.stringify(jsonResp1)
+                        statusCode: 401,
+                        body: JSON.stringify(jsonResp1)
                     };
                 }
             });
             mock.expects('request').withArgs(fetchTokenArgs).returns({
                 end: function () {
                     return {
-                        status: 200,
-                        data: JSON.stringify(jsonResp2)
+                        statusCode: 200,
+                        body: JSON.stringify(jsonResp2)
                     };
                 }
             });
 
-            var authManager = new CDAPAuthManager(username, password),
+            var authManager = new CDAPAuthManager(),
                 authToken;
+
+            authManager.setConnectionInfo('localhost', 10000, false);
+            authManager.configure({username: username, password: password});
 
             if (authManager.isAuthEnabled()) {
                 authToken = authManager.getToken();

--- a/cdap-authentication-clients/javascript/test/authmanager-spec.js
+++ b/cdap-authentication-clients/javascript/test/authmanager-spec.js
@@ -13,6 +13,8 @@ describe('CDAP Auth manager tests', function () {
             expect(authManager).to.have.property('getToken');
             expect(authManager).to.have.property('configure');
             expect(authManager).to.have.property('setConnectionInfo');
+            expect(authManager).to.have.property('getRequiredCredentials');
+            expect(authManager).to.have.property('invalidateToken');
         });
 
         it('"configure" method could not be called without "username" or "password" field', function () {

--- a/cdap-authentication-clients/javascript/test/client.html
+++ b/cdap-authentication-clients/javascript/test/client.html
@@ -1,0 +1,25 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Mocha Tests</title>
+    <link rel="stylesheet" href="../bower_components/mocha/mocha.css" />
+  </head>
+  <body>
+    <div id="mocha"></div>
+    <script src="../bower_components/expect/index.js"></script>
+    <script src="../bower_components/mocha/mocha.js"></script>
+    <script src="samsam.js"></script>
+    <script src="formatio.js"></script>
+    <script src="sinon-server-1.10.3.js"></script>
+    <script>
+        mocha.setup('bdd');
+    </script>
+    <script src="../src/base64.js"></script>
+    <script src="../src/helper-browser.js"></script>
+    <script src="../src/authmanager.js"></script>
+    <script src="authmanager-browser.js"></script>
+    <script>
+       mocha.run();
+    </script>
+  </body>
+</html>

--- a/cdap-authentication-clients/javascript/test/formatio.js
+++ b/cdap-authentication-clients/javascript/test/formatio.js
@@ -1,0 +1,213 @@
+((typeof define === "function" && define.amd && function (m) {
+    define("formatio", ["samsam"], m);
+}) || (typeof module === "object" && function (m) {
+    module.exports = m(require("samsam"));
+}) || function (m) { this.formatio = m(this.samsam); }
+)(function (samsam) {
+    "use strict";
+
+    var formatio = {
+        excludeConstructors: ["Object", /^.$/],
+        quoteStrings: true,
+        limitChildrenCount: 0
+    };
+
+    var hasOwn = Object.prototype.hasOwnProperty;
+
+    var specialObjects = [];
+    if (typeof global !== "undefined") {
+        specialObjects.push({ object: global, value: "[object global]" });
+    }
+    if (typeof document !== "undefined") {
+        specialObjects.push({
+            object: document,
+            value: "[object HTMLDocument]"
+        });
+    }
+    if (typeof window !== "undefined") {
+        specialObjects.push({ object: window, value: "[object Window]" });
+    }
+
+    function functionName(func) {
+        if (!func) { return ""; }
+        if (func.displayName) { return func.displayName; }
+        if (func.name) { return func.name; }
+        var matches = func.toString().match(/function\s+([^\(]+)/m);
+        return (matches && matches[1]) || "";
+    }
+
+    function constructorName(f, object) {
+        var name = functionName(object && object.constructor);
+        var excludes = f.excludeConstructors ||
+                formatio.excludeConstructors || [];
+
+        var i, l;
+        for (i = 0, l = excludes.length; i < l; ++i) {
+            if (typeof excludes[i] === "string" && excludes[i] === name) {
+                return "";
+            } else if (excludes[i].test && excludes[i].test(name)) {
+                return "";
+            }
+        }
+
+        return name;
+    }
+
+    function isCircular(object, objects) {
+        if (typeof object !== "object") { return false; }
+        var i, l;
+        for (i = 0, l = objects.length; i < l; ++i) {
+            if (objects[i] === object) { return true; }
+        }
+        return false;
+    }
+
+    function ascii(f, object, processed, indent) {
+        if (typeof object === "string") {
+            var qs = f.quoteStrings;
+            var quote = typeof qs !== "boolean" || qs;
+            return processed || quote ? '"' + object + '"' : object;
+        }
+
+        if (typeof object === "function" && !(object instanceof RegExp)) {
+            return ascii.func(object);
+        }
+
+        processed = processed || [];
+
+        if (isCircular(object, processed)) { return "[Circular]"; }
+
+        if (Object.prototype.toString.call(object) === "[object Array]") {
+            return ascii.array.call(f, object, processed);
+        }
+
+        if (!object) { return String((1/object) === -Infinity ? "-0" : object); }
+        if (samsam.isElement(object)) { return ascii.element(object); }
+
+        if (typeof object.toString === "function" &&
+                object.toString !== Object.prototype.toString) {
+            return object.toString();
+        }
+
+        var i, l;
+        for (i = 0, l = specialObjects.length; i < l; i++) {
+            if (object === specialObjects[i].object) {
+                return specialObjects[i].value;
+            }
+        }
+
+        return ascii.object.call(f, object, processed, indent);
+    }
+
+    ascii.func = function (func) {
+        return "function " + functionName(func) + "() {}";
+    };
+
+    ascii.array = function (array, processed) {
+        processed = processed || [];
+        processed.push(array);
+        var pieces = [];
+        var i, l;
+        l = (this.limitChildrenCount > 0) ? 
+            Math.min(this.limitChildrenCount, array.length) : array.length;
+
+        for (i = 0; i < l; ++i) {
+            pieces.push(ascii(this, array[i], processed));
+        }
+
+        if(l < array.length)
+            pieces.push("[... " + (array.length - l) + " more elements]");
+
+        return "[" + pieces.join(", ") + "]";
+    };
+
+    ascii.object = function (object, processed, indent) {
+        processed = processed || [];
+        processed.push(object);
+        indent = indent || 0;
+        var pieces = [], properties = samsam.keys(object).sort();
+        var length = 3;
+        var prop, str, obj, i, k, l;
+        l = (this.limitChildrenCount > 0) ? 
+            Math.min(this.limitChildrenCount, properties.length) : properties.length;
+
+        for (i = 0; i < l; ++i) {
+            prop = properties[i];
+            obj = object[prop];
+
+            if (isCircular(obj, processed)) {
+                str = "[Circular]";
+            } else {
+                str = ascii(this, obj, processed, indent + 2);
+            }
+
+            str = (/\s/.test(prop) ? '"' + prop + '"' : prop) + ": " + str;
+            length += str.length;
+            pieces.push(str);
+        }
+
+        var cons = constructorName(this, object);
+        var prefix = cons ? "[" + cons + "] " : "";
+        var is = "";
+        for (i = 0, k = indent; i < k; ++i) { is += " "; }
+
+        if(l < properties.length)
+            pieces.push("[... " + (properties.length - l) + " more elements]");
+
+        if (length + indent > 80) {
+            return prefix + "{\n  " + is + pieces.join(",\n  " + is) + "\n" +
+                is + "}";
+        }
+        return prefix + "{ " + pieces.join(", ") + " }";
+    };
+
+    ascii.element = function (element) {
+        var tagName = element.tagName.toLowerCase();
+        var attrs = element.attributes, attr, pairs = [], attrName, i, l, val;
+
+        for (i = 0, l = attrs.length; i < l; ++i) {
+            attr = attrs.item(i);
+            attrName = attr.nodeName.toLowerCase().replace("html:", "");
+            val = attr.nodeValue;
+            if (attrName !== "contenteditable" || val !== "inherit") {
+                if (!!val) { pairs.push(attrName + "=\"" + val + "\""); }
+            }
+        }
+
+        var formatted = "<" + tagName + (pairs.length > 0 ? " " : "");
+        var content = element.innerHTML;
+
+        if (content.length > 20) {
+            content = content.substr(0, 20) + "[...]";
+        }
+
+        var res = formatted + pairs.join(" ") + ">" + content +
+                "</" + tagName + ">";
+
+        return res.replace(/ contentEditable="inherit"/, "");
+    };
+
+    function Formatio(options) {
+        for (var opt in options) {
+            this[opt] = options[opt];
+        }
+    }
+
+    Formatio.prototype = {
+        functionName: functionName,
+
+        configure: function (options) {
+            return new Formatio(options);
+        },
+
+        constructorName: function (object) {
+            return constructorName(this, object);
+        },
+
+        ascii: function (object, processed, indent) {
+            return ascii(this, object, processed, indent);
+        }
+    };
+
+    return Formatio.prototype;
+});

--- a/cdap-authentication-clients/javascript/test/samsam.js
+++ b/cdap-authentication-clients/javascript/test/samsam.js
@@ -1,0 +1,384 @@
+((typeof define === "function" && define.amd && function (m) { define("samsam", m); }) ||
+ (typeof module === "object" &&
+      function (m) { module.exports = m(); }) || // Node
+ function (m) { this.samsam = m(); } // Browser globals
+)(function () {
+    var o = Object.prototype;
+    var div = typeof document !== "undefined" && document.createElement("div");
+
+    function isNaN(value) {
+        // Unlike global isNaN, this avoids type coercion
+        // typeof check avoids IE host object issues, hat tip to
+        // lodash
+        var val = value; // JsLint thinks value !== value is "weird"
+        return typeof value === "number" && value !== val;
+    }
+
+    function getClass(value) {
+        // Returns the internal [[Class]] by calling Object.prototype.toString
+        // with the provided value as this. Return value is a string, naming the
+        // internal class, e.g. "Array"
+        return o.toString.call(value).split(/[ \]]/)[1];
+    }
+
+    /**
+     * @name samsam.isArguments
+     * @param Object object
+     *
+     * Returns ``true`` if ``object`` is an ``arguments`` object,
+     * ``false`` otherwise.
+     */
+    function isArguments(object) {
+        if (getClass(object) === 'Arguments') { return true; }
+        if (typeof object !== "object" || typeof object.length !== "number" ||
+                getClass(object) === "Array") {
+            return false;
+        }
+        if (typeof object.callee == "function") { return true; }
+        try {
+            object[object.length] = 6;
+            delete object[object.length];
+        } catch (e) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @name samsam.isElement
+     * @param Object object
+     *
+     * Returns ``true`` if ``object`` is a DOM element node. Unlike
+     * Underscore.js/lodash, this function will return ``false`` if ``object``
+     * is an *element-like* object, i.e. a regular object with a ``nodeType``
+     * property that holds the value ``1``.
+     */
+    function isElement(object) {
+        if (!object || object.nodeType !== 1 || !div) { return false; }
+        try {
+            object.appendChild(div);
+            object.removeChild(div);
+        } catch (e) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @name samsam.keys
+     * @param Object object
+     *
+     * Return an array of own property names.
+     */
+    function keys(object) {
+        var ks = [], prop;
+        for (prop in object) {
+            if (o.hasOwnProperty.call(object, prop)) { ks.push(prop); }
+        }
+        return ks;
+    }
+
+    /**
+     * @name samsam.isDate
+     * @param Object value
+     *
+     * Returns true if the object is a ``Date``, or *date-like*. Duck typing
+     * of date objects work by checking that the object has a ``getTime``
+     * function whose return value equals the return value from the object's
+     * ``valueOf``.
+     */
+    function isDate(value) {
+        return typeof value.getTime == "function" &&
+            value.getTime() == value.valueOf();
+    }
+
+    /**
+     * @name samsam.isNegZero
+     * @param Object value
+     *
+     * Returns ``true`` if ``value`` is ``-0``.
+     */
+    function isNegZero(value) {
+        return value === 0 && 1 / value === -Infinity;
+    }
+
+    /**
+     * @name samsam.equal
+     * @param Object obj1
+     * @param Object obj2
+     *
+     * Returns ``true`` if two objects are strictly equal. Compared to
+     * ``===`` there are two exceptions:
+     *
+     *   - NaN is considered equal to NaN
+     *   - -0 and +0 are not considered equal
+     */
+    function identical(obj1, obj2) {
+        if (obj1 === obj2 || (isNaN(obj1) && isNaN(obj2))) {
+            return obj1 !== 0 || isNegZero(obj1) === isNegZero(obj2);
+        }
+    }
+
+
+    /**
+     * @name samsam.deepEqual
+     * @param Object obj1
+     * @param Object obj2
+     *
+     * Deep equal comparison. Two values are "deep equal" if:
+     *
+     *   - They are equal, according to samsam.identical
+     *   - They are both date objects representing the same time
+     *   - They are both arrays containing elements that are all deepEqual
+     *   - They are objects with the same set of properties, and each property
+     *     in ``obj1`` is deepEqual to the corresponding property in ``obj2``
+     *
+     * Supports cyclic objects.
+     */
+    function deepEqualCyclic(obj1, obj2) {
+
+        // used for cyclic comparison
+        // contain already visited objects
+        var objects1 = [],
+            objects2 = [],
+        // contain pathes (position in the object structure)
+        // of the already visited objects
+        // indexes same as in objects arrays
+            paths1 = [],
+            paths2 = [],
+        // contains combinations of already compared objects
+        // in the manner: { "$1['ref']$2['ref']": true }
+            compared = {};
+
+        /**
+         * used to check, if the value of a property is an object
+         * (cyclic logic is only needed for objects)
+         * only needed for cyclic logic
+         */
+        function isObject(value) {
+
+            if (typeof value === 'object' && value !== null &&
+                    !(value instanceof Boolean) &&
+                    !(value instanceof Date)    &&
+                    !(value instanceof Number)  &&
+                    !(value instanceof RegExp)  &&
+                    !(value instanceof String)) {
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /**
+         * returns the index of the given object in the
+         * given objects array, -1 if not contained
+         * only needed for cyclic logic
+         */
+        function getIndex(objects, obj) {
+
+            var i;
+            for (i = 0; i < objects.length; i++) {
+                if (objects[i] === obj) {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        // does the recursion for the deep equal check
+        return (function deepEqual(obj1, obj2, path1, path2) {
+            var type1 = typeof obj1;
+            var type2 = typeof obj2;
+
+            // == null also matches undefined
+            if (obj1 === obj2 ||
+                    isNaN(obj1) || isNaN(obj2) ||
+                    obj1 == null || obj2 == null ||
+                    type1 !== "object" || type2 !== "object") {
+
+                return identical(obj1, obj2);
+            }
+
+            // Elements are only equal if identical(expected, actual)
+            if (isElement(obj1) || isElement(obj2)) { return false; }
+
+            var isDate1 = isDate(obj1), isDate2 = isDate(obj2);
+            if (isDate1 || isDate2) {
+                if (!isDate1 || !isDate2 || obj1.getTime() !== obj2.getTime()) {
+                    return false;
+                }
+            }
+
+            if (obj1 instanceof RegExp && obj2 instanceof RegExp) {
+                if (obj1.toString() !== obj2.toString()) { return false; }
+            }
+
+            var class1 = getClass(obj1);
+            var class2 = getClass(obj2);
+            var keys1 = keys(obj1);
+            var keys2 = keys(obj2);
+
+            if (isArguments(obj1) || isArguments(obj2)) {
+                if (obj1.length !== obj2.length) { return false; }
+            } else {
+                if (type1 !== type2 || class1 !== class2 ||
+                        keys1.length !== keys2.length) {
+                    return false;
+                }
+            }
+
+            var key, i, l,
+                // following vars are used for the cyclic logic
+                value1, value2,
+                isObject1, isObject2,
+                index1, index2,
+                newPath1, newPath2;
+
+            for (i = 0, l = keys1.length; i < l; i++) {
+                key = keys1[i];
+                if (!o.hasOwnProperty.call(obj2, key)) {
+                    return false;
+                }
+
+                // Start of the cyclic logic
+
+                value1 = obj1[key];
+                value2 = obj2[key];
+
+                isObject1 = isObject(value1);
+                isObject2 = isObject(value2);
+
+                // determine, if the objects were already visited
+                // (it's faster to check for isObject first, than to
+                // get -1 from getIndex for non objects)
+                index1 = isObject1 ? getIndex(objects1, value1) : -1;
+                index2 = isObject2 ? getIndex(objects2, value2) : -1;
+
+                // determine the new pathes of the objects
+                // - for non cyclic objects the current path will be extended
+                //   by current property name
+                // - for cyclic objects the stored path is taken
+                newPath1 = index1 !== -1
+                    ? paths1[index1]
+                    : path1 + '[' + JSON.stringify(key) + ']';
+                newPath2 = index2 !== -1
+                    ? paths2[index2]
+                    : path2 + '[' + JSON.stringify(key) + ']';
+
+                // stop recursion if current objects are already compared
+                if (compared[newPath1 + newPath2]) {
+                    return true;
+                }
+
+                // remember the current objects and their pathes
+                if (index1 === -1 && isObject1) {
+                    objects1.push(value1);
+                    paths1.push(newPath1);
+                }
+                if (index2 === -1 && isObject2) {
+                    objects2.push(value2);
+                    paths2.push(newPath2);
+                }
+
+                // remember that the current objects are already compared
+                if (isObject1 && isObject2) {
+                    compared[newPath1 + newPath2] = true;
+                }
+
+                // End of cyclic logic
+
+                // neither value1 nor value2 is a cycle
+                // continue with next level
+                if (!deepEqual(value1, value2, newPath1, newPath2)) {
+                    return false;
+                }
+            }
+
+            return true;
+
+        }(obj1, obj2, '$1', '$2'));
+    }
+
+    var match;
+
+    function arrayContains(array, subset) {
+        if (subset.length === 0) { return true; }
+        var i, l, j, k;
+        for (i = 0, l = array.length; i < l; ++i) {
+            if (match(array[i], subset[0])) {
+                for (j = 0, k = subset.length; j < k; ++j) {
+                    if (!match(array[i + j], subset[j])) { return false; }
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @name samsam.match
+     * @param Object object
+     * @param Object matcher
+     *
+     * Compare arbitrary value ``object`` with matcher.
+     */
+    match = function match(object, matcher) {
+        if (matcher && typeof matcher.test === "function") {
+            return matcher.test(object);
+        }
+
+        if (typeof matcher === "function") {
+            return matcher(object) === true;
+        }
+
+        if (typeof matcher === "string") {
+            matcher = matcher.toLowerCase();
+            var notNull = typeof object === "string" || !!object;
+            return notNull &&
+                (String(object)).toLowerCase().indexOf(matcher) >= 0;
+        }
+
+        if (typeof matcher === "number") {
+            return matcher === object;
+        }
+
+        if (typeof matcher === "boolean") {
+            return matcher === object;
+        }
+
+        if (getClass(object) === "Array" && getClass(matcher) === "Array") {
+            return arrayContains(object, matcher);
+        }
+
+        if (matcher && typeof matcher === "object") {
+            var prop;
+            for (prop in matcher) {
+                var value = object[prop];
+                if (typeof value === "undefined" &&
+                        typeof object.getAttribute === "function") {
+                    value = object.getAttribute(prop);
+                }
+                if (typeof value === "undefined" || !match(value, matcher[prop])) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        throw new Error("Matcher was not a string, a number, a " +
+                        "function, a boolean or an object");
+    };
+
+    return {
+        isArguments: isArguments,
+        isElement: isElement,
+        isDate: isDate,
+        isNegZero: isNegZero,
+        identical: identical,
+        deepEqual: deepEqualCyclic,
+        match: match,
+        keys: keys
+    };
+});

--- a/cdap-authentication-clients/javascript/test/sinon-server-1.10.3.js
+++ b/cdap-authentication-clients/javascript/test/sinon-server-1.10.3.js
@@ -1,0 +1,1791 @@
+/**
+ * Sinon.JS 1.10.3, 2014/07/11
+ *
+ * @author Christian Johansen (christian@cjohansen.no)
+ * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
+ *
+ * (The BSD License)
+ * 
+ * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ *     * Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice,
+ *       this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of Christian Johansen nor the names of his contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*jslint eqeqeq: false, onevar: false, forin: true, nomen: false, regexp: false, plusplus: false*/
+/*global module, require, __dirname, document*/
+/**
+ * Sinon core utilities. For internal use only.
+ *
+ * @author Christian Johansen (christian@cjohansen.no)
+ * @license BSD
+ *
+ * Copyright (c) 2010-2013 Christian Johansen
+ */
+
+var sinon = (function (formatio) {
+    var div = typeof document != "undefined" && document.createElement("div");
+    var hasOwn = Object.prototype.hasOwnProperty;
+
+    function isDOMNode(obj) {
+        var success = false;
+
+        try {
+            obj.appendChild(div);
+            success = div.parentNode == obj;
+        } catch (e) {
+            return false;
+        } finally {
+            try {
+                obj.removeChild(div);
+            } catch (e) {
+                // Remove failed, not much we can do about that
+            }
+        }
+
+        return success;
+    }
+
+    function isElement(obj) {
+        return div && obj && obj.nodeType === 1 && isDOMNode(obj);
+    }
+
+    function isFunction(obj) {
+        return typeof obj === "function" || !!(obj && obj.constructor && obj.call && obj.apply);
+    }
+
+    function isReallyNaN(val) {
+        return typeof val === 'number' && isNaN(val);
+    }
+
+    function mirrorProperties(target, source) {
+        for (var prop in source) {
+            if (!hasOwn.call(target, prop)) {
+                target[prop] = source[prop];
+            }
+        }
+    }
+
+    function isRestorable (obj) {
+        return typeof obj === "function" && typeof obj.restore === "function" && obj.restore.sinon;
+    }
+
+    var sinon = {
+        wrapMethod: function wrapMethod(object, property, method) {
+            if (!object) {
+                throw new TypeError("Should wrap property of object");
+            }
+
+            if (typeof method != "function") {
+                throw new TypeError("Method wrapper should be function");
+            }
+
+            var wrappedMethod = object[property],
+                error;
+
+            if (!isFunction(wrappedMethod)) {
+                error = new TypeError("Attempted to wrap " + (typeof wrappedMethod) + " property " +
+                                    property + " as function");
+            } else if (wrappedMethod.restore && wrappedMethod.restore.sinon) {
+                error = new TypeError("Attempted to wrap " + property + " which is already wrapped");
+            } else if (wrappedMethod.calledBefore) {
+                var verb = !!wrappedMethod.returns ? "stubbed" : "spied on";
+                error = new TypeError("Attempted to wrap " + property + " which is already " + verb);
+            }
+
+            if (error) {
+                if (wrappedMethod && wrappedMethod._stack) {
+                    error.stack += '\n--------------\n' + wrappedMethod._stack;
+                }
+                throw error;
+            }
+
+            // IE 8 does not support hasOwnProperty on the window object and Firefox has a problem
+            // when using hasOwn.call on objects from other frames.
+            var owned = object.hasOwnProperty ? object.hasOwnProperty(property) : hasOwn.call(object, property);
+            object[property] = method;
+            method.displayName = property;
+            // Set up a stack trace which can be used later to find what line of
+            // code the original method was created on.
+            method._stack = (new Error('Stack Trace for original')).stack;
+
+            method.restore = function () {
+                // For prototype properties try to reset by delete first.
+                // If this fails (ex: localStorage on mobile safari) then force a reset
+                // via direct assignment.
+                if (!owned) {
+                    delete object[property];
+                }
+                if (object[property] === method) {
+                    object[property] = wrappedMethod;
+                }
+            };
+
+            method.restore.sinon = true;
+            mirrorProperties(method, wrappedMethod);
+
+            return method;
+        },
+
+        extend: function extend(target) {
+            for (var i = 1, l = arguments.length; i < l; i += 1) {
+                for (var prop in arguments[i]) {
+                    if (arguments[i].hasOwnProperty(prop)) {
+                        target[prop] = arguments[i][prop];
+                    }
+
+                    // DONT ENUM bug, only care about toString
+                    if (arguments[i].hasOwnProperty("toString") &&
+                        arguments[i].toString != target.toString) {
+                        target.toString = arguments[i].toString;
+                    }
+                }
+            }
+
+            return target;
+        },
+
+        create: function create(proto) {
+            var F = function () {};
+            F.prototype = proto;
+            return new F();
+        },
+
+        deepEqual: function deepEqual(a, b) {
+            if (sinon.match && sinon.match.isMatcher(a)) {
+                return a.test(b);
+            }
+
+            if (typeof a != 'object' || typeof b != 'object') {
+                if (isReallyNaN(a) && isReallyNaN(b)) {
+                    return true;
+                } else {
+                    return a === b;
+                }
+            }
+
+            if (isElement(a) || isElement(b)) {
+                return a === b;
+            }
+
+            if (a === b) {
+                return true;
+            }
+
+            if ((a === null && b !== null) || (a !== null && b === null)) {
+                return false;
+            }
+
+            if (a instanceof RegExp && b instanceof RegExp) {
+              return (a.source === b.source) && (a.global === b.global) &&
+                (a.ignoreCase === b.ignoreCase) && (a.multiline === b.multiline);
+            }
+
+            var aString = Object.prototype.toString.call(a);
+            if (aString != Object.prototype.toString.call(b)) {
+                return false;
+            }
+
+            if (aString == "[object Date]") {
+                return a.valueOf() === b.valueOf();
+            }
+
+            var prop, aLength = 0, bLength = 0;
+
+            if (aString == "[object Array]" && a.length !== b.length) {
+                return false;
+            }
+
+            for (prop in a) {
+                aLength += 1;
+
+                if (!(prop in b)) {
+                    return false;
+                }
+
+                if (!deepEqual(a[prop], b[prop])) {
+                    return false;
+                }
+            }
+
+            for (prop in b) {
+                bLength += 1;
+            }
+
+            return aLength == bLength;
+        },
+
+        functionName: function functionName(func) {
+            var name = func.displayName || func.name;
+
+            // Use function decomposition as a last resort to get function
+            // name. Does not rely on function decomposition to work - if it
+            // doesn't debugging will be slightly less informative
+            // (i.e. toString will say 'spy' rather than 'myFunc').
+            if (!name) {
+                var matches = func.toString().match(/function ([^\s\(]+)/);
+                name = matches && matches[1];
+            }
+
+            return name;
+        },
+
+        functionToString: function toString() {
+            if (this.getCall && this.callCount) {
+                var thisValue, prop, i = this.callCount;
+
+                while (i--) {
+                    thisValue = this.getCall(i).thisValue;
+
+                    for (prop in thisValue) {
+                        if (thisValue[prop] === this) {
+                            return prop;
+                        }
+                    }
+                }
+            }
+
+            return this.displayName || "sinon fake";
+        },
+
+        getConfig: function (custom) {
+            var config = {};
+            custom = custom || {};
+            var defaults = sinon.defaultConfig;
+
+            for (var prop in defaults) {
+                if (defaults.hasOwnProperty(prop)) {
+                    config[prop] = custom.hasOwnProperty(prop) ? custom[prop] : defaults[prop];
+                }
+            }
+
+            return config;
+        },
+
+        format: function (val) {
+            return "" + val;
+        },
+
+        defaultConfig: {
+            injectIntoThis: true,
+            injectInto: null,
+            properties: ["spy", "stub", "mock", "clock", "server", "requests"],
+            useFakeTimers: true,
+            useFakeServer: true
+        },
+
+        timesInWords: function timesInWords(count) {
+            return count == 1 && "once" ||
+                count == 2 && "twice" ||
+                count == 3 && "thrice" ||
+                (count || 0) + " times";
+        },
+
+        calledInOrder: function (spies) {
+            for (var i = 1, l = spies.length; i < l; i++) {
+                if (!spies[i - 1].calledBefore(spies[i]) || !spies[i].called) {
+                    return false;
+                }
+            }
+
+            return true;
+        },
+
+        orderByFirstCall: function (spies) {
+            return spies.sort(function (a, b) {
+                // uuid, won't ever be equal
+                var aCall = a.getCall(0);
+                var bCall = b.getCall(0);
+                var aId = aCall && aCall.callId || -1;
+                var bId = bCall && bCall.callId || -1;
+
+                return aId < bId ? -1 : 1;
+            });
+        },
+
+        log: function () {},
+
+        logError: function (label, err) {
+            var msg = label + " threw exception: ";
+            sinon.log(msg + "[" + err.name + "] " + err.message);
+            if (err.stack) { sinon.log(err.stack); }
+
+            setTimeout(function () {
+                err.message = msg + err.message;
+                throw err;
+            }, 0);
+        },
+
+        typeOf: function (value) {
+            if (value === null) {
+                return "null";
+            }
+            else if (value === undefined) {
+                return "undefined";
+            }
+            var string = Object.prototype.toString.call(value);
+            return string.substring(8, string.length - 1).toLowerCase();
+        },
+
+        createStubInstance: function (constructor) {
+            if (typeof constructor !== "function") {
+                throw new TypeError("The constructor should be a function.");
+            }
+            return sinon.stub(sinon.create(constructor.prototype));
+        },
+
+        restore: function (object) {
+            if (object !== null && typeof object === "object") {
+                for (var prop in object) {
+                    if (isRestorable(object[prop])) {
+                        object[prop].restore();
+                    }
+                }
+            }
+            else if (isRestorable(object)) {
+                object.restore();
+            }
+        }
+    };
+
+    var isNode = typeof module !== "undefined" && module.exports && typeof require == "function";
+    var isAMD = typeof define === 'function' && typeof define.amd === 'object' && define.amd;
+
+    function makePublicAPI(require, exports, module) {
+        module.exports = sinon;
+        sinon.spy = require("./sinon/spy");
+        sinon.spyCall = require("./sinon/call");
+        sinon.behavior = require("./sinon/behavior");
+        sinon.stub = require("./sinon/stub");
+        sinon.mock = require("./sinon/mock");
+        sinon.collection = require("./sinon/collection");
+        sinon.assert = require("./sinon/assert");
+        sinon.sandbox = require("./sinon/sandbox");
+        sinon.test = require("./sinon/test");
+        sinon.testCase = require("./sinon/test_case");
+        sinon.match = require("./sinon/match");
+    }
+
+    if (isAMD) {
+        define(makePublicAPI);
+    } else if (isNode) {
+        try {
+            formatio = require("formatio");
+        } catch (e) {}
+        makePublicAPI(require, exports, module);
+    }
+
+    if (formatio) {
+        var formatter = formatio.configure({ quoteStrings: false });
+        sinon.format = function () {
+            return formatter.ascii.apply(formatter, arguments);
+        };
+    } else if (isNode) {
+        try {
+            var util = require("util");
+            sinon.format = function (value) {
+                return typeof value == "object" && value.toString === Object.prototype.toString ? util.inspect(value) : value;
+            };
+        } catch (e) {
+            /* Node, but no util module - would be very old, but better safe than
+             sorry */
+        }
+    }
+
+    return sinon;
+}(typeof formatio == "object" && formatio));
+
+/*jslint eqeqeq: false, onevar: false*/
+/*global sinon, module, require, ActiveXObject, XMLHttpRequest, DOMParser*/
+/**
+ * Minimal Event interface implementation
+ *
+ * Original implementation by Sven Fuchs: https://gist.github.com/995028
+ * Modifications and tests by Christian Johansen.
+ *
+ * @author Sven Fuchs (svenfuchs@artweb-design.de)
+ * @author Christian Johansen (christian@cjohansen.no)
+ * @license BSD
+ *
+ * Copyright (c) 2011 Sven Fuchs, Christian Johansen
+ */
+
+if (typeof sinon == "undefined") {
+    this.sinon = {};
+}
+
+(function () {
+    var push = [].push;
+
+    sinon.Event = function Event(type, bubbles, cancelable, target) {
+        this.initEvent(type, bubbles, cancelable, target);
+    };
+
+    sinon.Event.prototype = {
+        initEvent: function(type, bubbles, cancelable, target) {
+            this.type = type;
+            this.bubbles = bubbles;
+            this.cancelable = cancelable;
+            this.target = target;
+        },
+
+        stopPropagation: function () {},
+
+        preventDefault: function () {
+            this.defaultPrevented = true;
+        }
+    };
+
+    sinon.ProgressEvent = function ProgressEvent(type, progressEventRaw, target) {
+        this.initEvent(type, false, false, target);
+        this.loaded = progressEventRaw.loaded || null;
+        this.total = progressEventRaw.total || null;
+    };
+
+    sinon.ProgressEvent.prototype = new sinon.Event();
+
+    sinon.ProgressEvent.prototype.constructor =  sinon.ProgressEvent;
+
+    sinon.CustomEvent = function CustomEvent(type, customData, target) {
+        this.initEvent(type, false, false, target);
+        this.detail = customData.detail || null;
+    };
+
+    sinon.CustomEvent.prototype = new sinon.Event();
+
+    sinon.CustomEvent.prototype.constructor =  sinon.CustomEvent;
+
+    sinon.EventTarget = {
+        addEventListener: function addEventListener(event, listener) {
+            this.eventListeners = this.eventListeners || {};
+            this.eventListeners[event] = this.eventListeners[event] || [];
+            push.call(this.eventListeners[event], listener);
+        },
+
+        removeEventListener: function removeEventListener(event, listener) {
+            var listeners = this.eventListeners && this.eventListeners[event] || [];
+
+            for (var i = 0, l = listeners.length; i < l; ++i) {
+                if (listeners[i] == listener) {
+                    return listeners.splice(i, 1);
+                }
+            }
+        },
+
+        dispatchEvent: function dispatchEvent(event) {
+            var type = event.type;
+            var listeners = this.eventListeners && this.eventListeners[type] || [];
+
+            for (var i = 0; i < listeners.length; i++) {
+                if (typeof listeners[i] == "function") {
+                    listeners[i].call(this, event);
+                } else {
+                    listeners[i].handleEvent(event);
+                }
+            }
+
+            return !!event.defaultPrevented;
+        }
+    };
+}());
+
+/**
+ * @depend ../../sinon.js
+ * @depend event.js
+ */
+/*jslint eqeqeq: false, onevar: false*/
+/*global sinon, module, require, ActiveXObject, XMLHttpRequest, DOMParser*/
+/**
+ * Fake XMLHttpRequest object
+ *
+ * @author Christian Johansen (christian@cjohansen.no)
+ * @license BSD
+ *
+ * Copyright (c) 2010-2013 Christian Johansen
+ */
+
+// wrapper for global
+(function(global) {
+    if (typeof sinon === "undefined") {
+        global.sinon = {};
+    }
+
+    var supportsProgress = typeof ProgressEvent !== "undefined";
+    var supportsCustomEvent = typeof CustomEvent !== "undefined";
+    sinon.xhr = { XMLHttpRequest: global.XMLHttpRequest };
+    var xhr = sinon.xhr;
+    xhr.GlobalXMLHttpRequest = global.XMLHttpRequest;
+    xhr.GlobalActiveXObject = global.ActiveXObject;
+    xhr.supportsActiveX = typeof xhr.GlobalActiveXObject != "undefined";
+    xhr.supportsXHR = typeof xhr.GlobalXMLHttpRequest != "undefined";
+    xhr.workingXHR = xhr.supportsXHR ? xhr.GlobalXMLHttpRequest : xhr.supportsActiveX
+                                     ? function() { return new xhr.GlobalActiveXObject("MSXML2.XMLHTTP.3.0") } : false;
+    xhr.supportsCORS = xhr.supportsXHR && 'withCredentials' in (new sinon.xhr.GlobalXMLHttpRequest());
+
+    /*jsl:ignore*/
+    var unsafeHeaders = {
+        "Accept-Charset": true,
+        "Accept-Encoding": true,
+        "Connection": true,
+        "Content-Length": true,
+        "Cookie": true,
+        "Cookie2": true,
+        "Content-Transfer-Encoding": true,
+        "Date": true,
+        "Expect": true,
+        "Host": true,
+        "Keep-Alive": true,
+        "Referer": true,
+        "TE": true,
+        "Trailer": true,
+        "Transfer-Encoding": true,
+        "Upgrade": true,
+        "User-Agent": true,
+        "Via": true
+    };
+    /*jsl:end*/
+
+    function FakeXMLHttpRequest() {
+        this.readyState = FakeXMLHttpRequest.UNSENT;
+        this.requestHeaders = {};
+        this.requestBody = null;
+        this.status = 0;
+        this.statusText = "";
+        this.upload = new UploadProgress();
+        if (sinon.xhr.supportsCORS) {
+            this.withCredentials = false;
+        }
+
+
+        var xhr = this;
+        var events = ["loadstart", "load", "abort", "loadend"];
+
+        function addEventListener(eventName) {
+            xhr.addEventListener(eventName, function (event) {
+                var listener = xhr["on" + eventName];
+
+                if (listener && typeof listener == "function") {
+                    listener.call(this, event);
+                }
+            });
+        }
+
+        for (var i = events.length - 1; i >= 0; i--) {
+            addEventListener(events[i]);
+        }
+
+        if (typeof FakeXMLHttpRequest.onCreate == "function") {
+            FakeXMLHttpRequest.onCreate(this);
+        }
+    }
+
+    // An upload object is created for each
+    // FakeXMLHttpRequest and allows upload
+    // events to be simulated using uploadProgress
+    // and uploadError.
+    function UploadProgress() {
+        this.eventListeners = {
+            "progress": [],
+            "load": [],
+            "abort": [],
+            "error": []
+        }
+    }
+
+    UploadProgress.prototype.addEventListener = function(event, listener) {
+        this.eventListeners[event].push(listener);
+    };
+
+    UploadProgress.prototype.removeEventListener = function(event, listener) {
+        var listeners = this.eventListeners[event] || [];
+
+        for (var i = 0, l = listeners.length; i < l; ++i) {
+            if (listeners[i] == listener) {
+                return listeners.splice(i, 1);
+            }
+        }
+    };
+
+    UploadProgress.prototype.dispatchEvent = function(event) {
+        var listeners = this.eventListeners[event.type] || [];
+
+        for (var i = 0, listener; (listener = listeners[i]) != null; i++) {
+            listener(event);
+        }
+    };
+
+    function verifyState(xhr) {
+        if (xhr.readyState !== FakeXMLHttpRequest.OPENED) {
+            throw new Error("INVALID_STATE_ERR");
+        }
+
+        if (xhr.sendFlag) {
+            throw new Error("INVALID_STATE_ERR");
+        }
+    }
+
+    // filtering to enable a white-list version of Sinon FakeXhr,
+    // where whitelisted requests are passed through to real XHR
+    function each(collection, callback) {
+        if (!collection) return;
+        for (var i = 0, l = collection.length; i < l; i += 1) {
+            callback(collection[i]);
+        }
+    }
+    function some(collection, callback) {
+        for (var index = 0; index < collection.length; index++) {
+            if(callback(collection[index]) === true) return true;
+        }
+        return false;
+    }
+    // largest arity in XHR is 5 - XHR#open
+    var apply = function(obj,method,args) {
+        switch(args.length) {
+        case 0: return obj[method]();
+        case 1: return obj[method](args[0]);
+        case 2: return obj[method](args[0],args[1]);
+        case 3: return obj[method](args[0],args[1],args[2]);
+        case 4: return obj[method](args[0],args[1],args[2],args[3]);
+        case 5: return obj[method](args[0],args[1],args[2],args[3],args[4]);
+        }
+    };
+
+    FakeXMLHttpRequest.filters = [];
+    FakeXMLHttpRequest.addFilter = function(fn) {
+        this.filters.push(fn)
+    };
+    var IE6Re = /MSIE 6/;
+    FakeXMLHttpRequest.defake = function(fakeXhr,xhrArgs) {
+        var xhr = new sinon.xhr.workingXHR();
+        each(["open","setRequestHeader","send","abort","getResponseHeader",
+              "getAllResponseHeaders","addEventListener","overrideMimeType","removeEventListener"],
+             function(method) {
+                 fakeXhr[method] = function() {
+                   return apply(xhr,method,arguments);
+                 };
+             });
+
+        var copyAttrs = function(args) {
+            each(args, function(attr) {
+              try {
+                fakeXhr[attr] = xhr[attr]
+              } catch(e) {
+                if(!IE6Re.test(navigator.userAgent)) throw e;
+              }
+            });
+        };
+
+        var stateChange = function() {
+            fakeXhr.readyState = xhr.readyState;
+            if(xhr.readyState >= FakeXMLHttpRequest.HEADERS_RECEIVED) {
+                copyAttrs(["status","statusText"]);
+            }
+            if(xhr.readyState >= FakeXMLHttpRequest.LOADING) {
+                copyAttrs(["responseText"]);
+            }
+            if(xhr.readyState === FakeXMLHttpRequest.DONE) {
+                copyAttrs(["responseXML"]);
+            }
+            if(fakeXhr.onreadystatechange) fakeXhr.onreadystatechange.call(fakeXhr, { target: fakeXhr });
+        };
+        if(xhr.addEventListener) {
+          for(var event in fakeXhr.eventListeners) {
+              if(fakeXhr.eventListeners.hasOwnProperty(event)) {
+                  each(fakeXhr.eventListeners[event],function(handler) {
+                      xhr.addEventListener(event, handler);
+                  });
+              }
+          }
+          xhr.addEventListener("readystatechange",stateChange);
+        } else {
+          xhr.onreadystatechange = stateChange;
+        }
+        apply(xhr,"open",xhrArgs);
+    };
+    FakeXMLHttpRequest.useFilters = false;
+
+    function verifyRequestOpened(xhr) {
+        if (xhr.readyState != FakeXMLHttpRequest.OPENED) {
+            throw new Error("INVALID_STATE_ERR - " + xhr.readyState);
+        }
+    }
+
+    function verifyRequestSent(xhr) {
+        if (xhr.readyState == FakeXMLHttpRequest.DONE) {
+            throw new Error("Request done");
+        }
+    }
+
+    function verifyHeadersReceived(xhr) {
+        if (xhr.async && xhr.readyState != FakeXMLHttpRequest.HEADERS_RECEIVED) {
+            throw new Error("No headers received");
+        }
+    }
+
+    function verifyResponseBodyType(body) {
+        if (typeof body != "string") {
+            var error = new Error("Attempted to respond to fake XMLHttpRequest with " +
+                                 body + ", which is not a string.");
+            error.name = "InvalidBodyException";
+            throw error;
+        }
+    }
+
+    sinon.extend(FakeXMLHttpRequest.prototype, sinon.EventTarget, {
+        async: true,
+
+        open: function open(method, url, async, username, password) {
+            this.method = method;
+            this.url = url;
+            this.async = typeof async == "boolean" ? async : true;
+            this.username = username;
+            this.password = password;
+            this.responseText = null;
+            this.responseXML = null;
+            this.requestHeaders = {};
+            this.sendFlag = false;
+            if(sinon.FakeXMLHttpRequest.useFilters === true) {
+                var xhrArgs = arguments;
+                var defake = some(FakeXMLHttpRequest.filters,function(filter) {
+                    return filter.apply(this,xhrArgs)
+                });
+                if (defake) {
+                  return sinon.FakeXMLHttpRequest.defake(this,arguments);
+                }
+            }
+            this.readyStateChange(FakeXMLHttpRequest.OPENED);
+        },
+
+        readyStateChange: function readyStateChange(state) {
+            this.readyState = state;
+
+            if (typeof this.onreadystatechange == "function") {
+                try {
+                    this.onreadystatechange();
+                } catch (e) {
+                    sinon.logError("Fake XHR onreadystatechange handler", e);
+                }
+            }
+
+            this.dispatchEvent(new sinon.Event("readystatechange"));
+
+            switch (this.readyState) {
+                case FakeXMLHttpRequest.DONE:
+                    this.dispatchEvent(new sinon.Event("load", false, false, this));
+                    this.dispatchEvent(new sinon.Event("loadend", false, false, this));
+                    this.upload.dispatchEvent(new sinon.Event("load", false, false, this));
+                    if (supportsProgress) {
+                        this.upload.dispatchEvent(new sinon.ProgressEvent('progress', {loaded: 100, total: 100}));
+                    }
+                    break;
+            }
+        },
+
+        setRequestHeader: function setRequestHeader(header, value) {
+            verifyState(this);
+
+            if (unsafeHeaders[header] || /^(Sec-|Proxy-)/.test(header)) {
+                throw new Error("Refused to set unsafe header \"" + header + "\"");
+            }
+
+            if (this.requestHeaders[header]) {
+                this.requestHeaders[header] += "," + value;
+            } else {
+                this.requestHeaders[header] = value;
+            }
+        },
+
+        // Helps testing
+        setResponseHeaders: function setResponseHeaders(headers) {
+            verifyRequestOpened(this);
+            this.responseHeaders = {};
+
+            for (var header in headers) {
+                if (headers.hasOwnProperty(header)) {
+                    this.responseHeaders[header] = headers[header];
+                }
+            }
+
+            if (this.async) {
+                this.readyStateChange(FakeXMLHttpRequest.HEADERS_RECEIVED);
+            } else {
+                this.readyState = FakeXMLHttpRequest.HEADERS_RECEIVED;
+            }
+        },
+
+        // Currently treats ALL data as a DOMString (i.e. no Document)
+        send: function send(data) {
+            verifyState(this);
+
+            if (!/^(get|head)$/i.test(this.method)) {
+                if (this.requestHeaders["Content-Type"]) {
+                    var value = this.requestHeaders["Content-Type"].split(";");
+                    this.requestHeaders["Content-Type"] = value[0] + ";charset=utf-8";
+                } else {
+                    this.requestHeaders["Content-Type"] = "text/plain;charset=utf-8";
+                }
+
+                this.requestBody = data;
+            }
+
+            this.errorFlag = false;
+            this.sendFlag = this.async;
+            this.readyStateChange(FakeXMLHttpRequest.OPENED);
+
+            if (typeof this.onSend == "function") {
+                this.onSend(this);
+            }
+
+            this.dispatchEvent(new sinon.Event("loadstart", false, false, this));
+        },
+
+        abort: function abort() {
+            this.aborted = true;
+            this.responseText = null;
+            this.errorFlag = true;
+            this.requestHeaders = {};
+
+            if (this.readyState > sinon.FakeXMLHttpRequest.UNSENT && this.sendFlag) {
+                this.readyStateChange(sinon.FakeXMLHttpRequest.DONE);
+                this.sendFlag = false;
+            }
+
+            this.readyState = sinon.FakeXMLHttpRequest.UNSENT;
+
+            this.dispatchEvent(new sinon.Event("abort", false, false, this));
+
+            this.upload.dispatchEvent(new sinon.Event("abort", false, false, this));
+
+            if (typeof this.onerror === "function") {
+                this.onerror();
+            }
+        },
+
+        getResponseHeader: function getResponseHeader(header) {
+            if (this.readyState < FakeXMLHttpRequest.HEADERS_RECEIVED) {
+                return null;
+            }
+
+            if (/^Set-Cookie2?$/i.test(header)) {
+                return null;
+            }
+
+            header = header.toLowerCase();
+
+            for (var h in this.responseHeaders) {
+                if (h.toLowerCase() == header) {
+                    return this.responseHeaders[h];
+                }
+            }
+
+            return null;
+        },
+
+        getAllResponseHeaders: function getAllResponseHeaders() {
+            if (this.readyState < FakeXMLHttpRequest.HEADERS_RECEIVED) {
+                return "";
+            }
+
+            var headers = "";
+
+            for (var header in this.responseHeaders) {
+                if (this.responseHeaders.hasOwnProperty(header) &&
+                    !/^Set-Cookie2?$/i.test(header)) {
+                    headers += header + ": " + this.responseHeaders[header] + "\r\n";
+                }
+            }
+
+            return headers;
+        },
+
+        setResponseBody: function setResponseBody(body) {
+            verifyRequestSent(this);
+            verifyHeadersReceived(this);
+            verifyResponseBodyType(body);
+
+            var chunkSize = this.chunkSize || 10;
+            var index = 0;
+            this.responseText = "";
+
+            do {
+                if (this.async) {
+                    this.readyStateChange(FakeXMLHttpRequest.LOADING);
+                }
+
+                this.responseText += body.substring(index, index + chunkSize);
+                index += chunkSize;
+            } while (index < body.length);
+
+            var type = this.getResponseHeader("Content-Type");
+
+            if (this.responseText &&
+                (!type || /(text\/xml)|(application\/xml)|(\+xml)/.test(type))) {
+                try {
+                    this.responseXML = FakeXMLHttpRequest.parseXML(this.responseText);
+                } catch (e) {
+                    // Unable to parse XML - no biggie
+                }
+            }
+
+            if (this.async) {
+                this.readyStateChange(FakeXMLHttpRequest.DONE);
+            } else {
+                this.readyState = FakeXMLHttpRequest.DONE;
+            }
+        },
+
+        respond: function respond(status, headers, body) {
+            this.status = typeof status == "number" ? status : 200;
+            this.statusText = FakeXMLHttpRequest.statusCodes[this.status];
+            this.setResponseHeaders(headers || {});
+            this.setResponseBody(body || "");
+        },
+
+        uploadProgress: function uploadProgress(progressEventRaw) {
+            if (supportsProgress) {
+                this.upload.dispatchEvent(new sinon.ProgressEvent("progress", progressEventRaw));
+            }
+        },
+
+        uploadError: function uploadError(error) {
+            if (supportsCustomEvent) {
+                this.upload.dispatchEvent(new sinon.CustomEvent("error", {"detail": error}));
+            }
+        }
+    });
+
+    sinon.extend(FakeXMLHttpRequest, {
+        UNSENT: 0,
+        OPENED: 1,
+        HEADERS_RECEIVED: 2,
+        LOADING: 3,
+        DONE: 4
+    });
+
+    // Borrowed from JSpec
+    FakeXMLHttpRequest.parseXML = function parseXML(text) {
+        var xmlDoc;
+
+        if (typeof DOMParser != "undefined") {
+            var parser = new DOMParser();
+            xmlDoc = parser.parseFromString(text, "text/xml");
+        } else {
+            xmlDoc = new ActiveXObject("Microsoft.XMLDOM");
+            xmlDoc.async = "false";
+            xmlDoc.loadXML(text);
+        }
+
+        return xmlDoc;
+    };
+
+    FakeXMLHttpRequest.statusCodes = {
+        100: "Continue",
+        101: "Switching Protocols",
+        200: "OK",
+        201: "Created",
+        202: "Accepted",
+        203: "Non-Authoritative Information",
+        204: "No Content",
+        205: "Reset Content",
+        206: "Partial Content",
+        300: "Multiple Choice",
+        301: "Moved Permanently",
+        302: "Found",
+        303: "See Other",
+        304: "Not Modified",
+        305: "Use Proxy",
+        307: "Temporary Redirect",
+        400: "Bad Request",
+        401: "Unauthorized",
+        402: "Payment Required",
+        403: "Forbidden",
+        404: "Not Found",
+        405: "Method Not Allowed",
+        406: "Not Acceptable",
+        407: "Proxy Authentication Required",
+        408: "Request Timeout",
+        409: "Conflict",
+        410: "Gone",
+        411: "Length Required",
+        412: "Precondition Failed",
+        413: "Request Entity Too Large",
+        414: "Request-URI Too Long",
+        415: "Unsupported Media Type",
+        416: "Requested Range Not Satisfiable",
+        417: "Expectation Failed",
+        422: "Unprocessable Entity",
+        500: "Internal Server Error",
+        501: "Not Implemented",
+        502: "Bad Gateway",
+        503: "Service Unavailable",
+        504: "Gateway Timeout",
+        505: "HTTP Version Not Supported"
+    };
+
+    sinon.useFakeXMLHttpRequest = function () {
+        sinon.FakeXMLHttpRequest.restore = function restore(keepOnCreate) {
+            if (xhr.supportsXHR) {
+                global.XMLHttpRequest = xhr.GlobalXMLHttpRequest;
+            }
+
+            if (xhr.supportsActiveX) {
+                global.ActiveXObject = xhr.GlobalActiveXObject;
+            }
+
+            delete sinon.FakeXMLHttpRequest.restore;
+
+            if (keepOnCreate !== true) {
+                delete sinon.FakeXMLHttpRequest.onCreate;
+            }
+        };
+        if (xhr.supportsXHR) {
+            global.XMLHttpRequest = sinon.FakeXMLHttpRequest;
+        }
+
+        if (xhr.supportsActiveX) {
+            global.ActiveXObject = function ActiveXObject(objId) {
+                if (objId == "Microsoft.XMLHTTP" || /^Msxml2\.XMLHTTP/i.test(objId)) {
+
+                    return new sinon.FakeXMLHttpRequest();
+                }
+
+                return new xhr.GlobalActiveXObject(objId);
+            };
+        }
+
+        return sinon.FakeXMLHttpRequest;
+    };
+
+    sinon.FakeXMLHttpRequest = FakeXMLHttpRequest;
+
+})((function(){ return typeof global === "object" ? global : this; })());
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = sinon;
+}
+
+/**
+ * @depend fake_xml_http_request.js
+ */
+/*jslint eqeqeq: false, onevar: false, regexp: false, plusplus: false*/
+/*global module, require, window*/
+/**
+ * The Sinon "server" mimics a web server that receives requests from
+ * sinon.FakeXMLHttpRequest and provides an API to respond to those requests,
+ * both synchronously and asynchronously. To respond synchronuously, canned
+ * answers have to be provided upfront.
+ *
+ * @author Christian Johansen (christian@cjohansen.no)
+ * @license BSD
+ *
+ * Copyright (c) 2010-2013 Christian Johansen
+ */
+
+if (typeof sinon == "undefined") {
+    var sinon = {};
+}
+
+sinon.fakeServer = (function () {
+    var push = [].push;
+    function F() {}
+
+    function create(proto) {
+        F.prototype = proto;
+        return new F();
+    }
+
+    function responseArray(handler) {
+        var response = handler;
+
+        if (Object.prototype.toString.call(handler) != "[object Array]") {
+            response = [200, {}, handler];
+        }
+
+        if (typeof response[2] != "string") {
+            throw new TypeError("Fake server response body should be string, but was " +
+                                typeof response[2]);
+        }
+
+        return response;
+    }
+
+    var wloc = typeof window !== "undefined" ? window.location : {};
+    var rCurrLoc = new RegExp("^" + wloc.protocol + "//" + wloc.host);
+
+    function matchOne(response, reqMethod, reqUrl) {
+        var rmeth = response.method;
+        var matchMethod = !rmeth || rmeth.toLowerCase() == reqMethod.toLowerCase();
+        var url = response.url;
+        var matchUrl = !url || url == reqUrl || (typeof url.test == "function" && url.test(reqUrl));
+
+        return matchMethod && matchUrl;
+    }
+
+    function match(response, request) {
+        var requestUrl = request.url;
+
+        if (!/^https?:\/\//.test(requestUrl) || rCurrLoc.test(requestUrl)) {
+            requestUrl = requestUrl.replace(rCurrLoc, "");
+        }
+
+        if (matchOne(response, this.getHTTPMethod(request), requestUrl)) {
+            if (typeof response.response == "function") {
+                var ru = response.url;
+                var args = [request].concat(ru && typeof ru.exec == "function" ? ru.exec(requestUrl).slice(1) : []);
+                return response.response.apply(response, args);
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    return {
+        create: function () {
+            var server = create(this);
+            this.xhr = sinon.useFakeXMLHttpRequest();
+            server.requests = [];
+
+            this.xhr.onCreate = function (xhrObj) {
+                server.addRequest(xhrObj);
+            };
+
+            return server;
+        },
+
+        addRequest: function addRequest(xhrObj) {
+            var server = this;
+            push.call(this.requests, xhrObj);
+
+            xhrObj.onSend = function () {
+                server.handleRequest(this);
+
+                if (server.autoRespond && !server.responding) {
+                    setTimeout(function () {
+                        server.responding = false;
+                        server.respond();
+                    }, server.autoRespondAfter || 10);
+
+                    server.responding = true;
+                }
+            };
+        },
+
+        getHTTPMethod: function getHTTPMethod(request) {
+            if (this.fakeHTTPMethods && /post/i.test(request.method)) {
+                var matches = (request.requestBody || "").match(/_method=([^\b;]+)/);
+                return !!matches ? matches[1] : request.method;
+            }
+
+            return request.method;
+        },
+
+        handleRequest: function handleRequest(xhr) {
+            if (xhr.async) {
+                if (!this.queue) {
+                    this.queue = [];
+                }
+
+                push.call(this.queue, xhr);
+            } else {
+                this.processRequest(xhr);
+            }
+        },
+
+        log: function(response, request) {
+            var str;
+
+            str =  "Request:\n"  + sinon.format(request)  + "\n\n";
+            str += "Response:\n" + sinon.format(response) + "\n\n";
+
+            sinon.log(str);
+        },
+
+        respondWith: function respondWith(method, url, body) {
+            if (arguments.length == 1 && typeof method != "function") {
+                this.response = responseArray(method);
+                return;
+            }
+
+            if (!this.responses) { this.responses = []; }
+
+            if (arguments.length == 1) {
+                body = method;
+                url = method = null;
+            }
+
+            if (arguments.length == 2) {
+                body = url;
+                url = method;
+                method = null;
+            }
+
+            push.call(this.responses, {
+                method: method,
+                url: url,
+                response: typeof body == "function" ? body : responseArray(body)
+            });
+        },
+
+        respond: function respond() {
+            if (arguments.length > 0) this.respondWith.apply(this, arguments);
+            var queue = this.queue || [];
+            var requests = queue.splice(0, queue.length);
+            var request;
+
+            while(request = requests.shift()) {
+                this.processRequest(request);
+            }
+        },
+
+        processRequest: function processRequest(request) {
+            try {
+                if (request.aborted) {
+                    return;
+                }
+
+                var response = this.response || [404, {}, ""];
+
+                if (this.responses) {
+                    for (var l = this.responses.length, i = l - 1; i >= 0; i--) {
+                        if (match.call(this, this.responses[i], request)) {
+                            response = this.responses[i].response;
+                            break;
+                        }
+                    }
+                }
+
+                if (request.readyState != 4) {
+                    sinon.fakeServer.log(response, request);
+
+                    request.respond(response[0], response[1], response[2]);
+                }
+            } catch (e) {
+                sinon.logError("Fake server request processing", e);
+            }
+        },
+
+        restore: function restore() {
+            return this.xhr.restore && this.xhr.restore.apply(this.xhr, arguments);
+        }
+    };
+}());
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = sinon;
+}
+
+/*jslint eqeqeq: false, plusplus: false, evil: true, onevar: false, browser: true, forin: false*/
+/*global module, require, window*/
+/**
+ * Fake timer API
+ * setTimeout
+ * setInterval
+ * clearTimeout
+ * clearInterval
+ * tick
+ * reset
+ * Date
+ *
+ * Inspired by jsUnitMockTimeOut from JsUnit
+ *
+ * @author Christian Johansen (christian@cjohansen.no)
+ * @license BSD
+ *
+ * Copyright (c) 2010-2013 Christian Johansen
+ */
+
+if (typeof sinon == "undefined") {
+    var sinon = {};
+}
+
+(function (global) {
+    // node expects setTimeout/setInterval to return a fn object w/ .ref()/.unref()
+    // browsers, a number.
+    // see https://github.com/cjohansen/Sinon.JS/pull/436
+    var timeoutResult = setTimeout(function() {}, 0);
+    var addTimerReturnsObject = typeof timeoutResult === 'object';
+    clearTimeout(timeoutResult);
+
+    var id = 1;
+
+    function addTimer(args, recurring) {
+        if (args.length === 0) {
+            throw new Error("Function requires at least 1 parameter");
+        }
+
+        if (typeof args[0] === "undefined") {
+            throw new Error("Callback must be provided to timer calls");
+        }
+
+        var toId = id++;
+        var delay = args[1] || 0;
+
+        if (!this.timeouts) {
+            this.timeouts = {};
+        }
+
+        this.timeouts[toId] = {
+            id: toId,
+            func: args[0],
+            callAt: this.now + delay,
+            invokeArgs: Array.prototype.slice.call(args, 2)
+        };
+
+        if (recurring === true) {
+            this.timeouts[toId].interval = delay;
+        }
+
+        if (addTimerReturnsObject) {
+            return {
+                id: toId,
+                ref: function() {},
+                unref: function() {}
+            };
+        }
+        else {
+            return toId;
+        }
+    }
+
+    function parseTime(str) {
+        if (!str) {
+            return 0;
+        }
+
+        var strings = str.split(":");
+        var l = strings.length, i = l;
+        var ms = 0, parsed;
+
+        if (l > 3 || !/^(\d\d:){0,2}\d\d?$/.test(str)) {
+            throw new Error("tick only understands numbers and 'h:m:s'");
+        }
+
+        while (i--) {
+            parsed = parseInt(strings[i], 10);
+
+            if (parsed >= 60) {
+                throw new Error("Invalid time " + str);
+            }
+
+            ms += parsed * Math.pow(60, (l - i - 1));
+        }
+
+        return ms * 1000;
+    }
+
+    function createObject(object) {
+        var newObject;
+
+        if (Object.create) {
+            newObject = Object.create(object);
+        } else {
+            var F = function () {};
+            F.prototype = object;
+            newObject = new F();
+        }
+
+        newObject.Date.clock = newObject;
+        return newObject;
+    }
+
+    sinon.clock = {
+        now: 0,
+
+        create: function create(now) {
+            var clock = createObject(this);
+
+            if (typeof now == "number") {
+                clock.now = now;
+            }
+
+            if (!!now && typeof now == "object") {
+                throw new TypeError("now should be milliseconds since UNIX epoch");
+            }
+
+            return clock;
+        },
+
+        setTimeout: function setTimeout(callback, timeout) {
+            return addTimer.call(this, arguments, false);
+        },
+
+        clearTimeout: function clearTimeout(timerId) {
+            if (!timerId) {
+                // null appears to be allowed in most browsers, and appears to be relied upon by some libraries, like Bootstrap carousel
+                return;
+            }
+            if (!this.timeouts) {
+                this.timeouts = [];
+            }
+            // in Node, timerId is an object with .ref()/.unref(), and
+            // its .id field is the actual timer id.
+            if (typeof timerId === 'object') {
+              timerId = timerId.id
+            }
+            if (timerId in this.timeouts) {
+                delete this.timeouts[timerId];
+            }
+        },
+
+        setInterval: function setInterval(callback, timeout) {
+            return addTimer.call(this, arguments, true);
+        },
+
+        clearInterval: function clearInterval(timerId) {
+            this.clearTimeout(timerId);
+        },
+
+        setImmediate: function setImmediate(callback) {
+            var passThruArgs = Array.prototype.slice.call(arguments, 1);
+
+            return addTimer.call(this, [callback, 0].concat(passThruArgs), false);
+        },
+
+        clearImmediate: function clearImmediate(timerId) {
+            this.clearTimeout(timerId);
+        },
+
+        tick: function tick(ms) {
+            ms = typeof ms == "number" ? ms : parseTime(ms);
+            var tickFrom = this.now, tickTo = this.now + ms, previous = this.now;
+            var timer = this.firstTimerInRange(tickFrom, tickTo);
+
+            var firstException;
+            while (timer && tickFrom <= tickTo) {
+                if (this.timeouts[timer.id]) {
+                    tickFrom = this.now = timer.callAt;
+                    try {
+                      this.callTimer(timer);
+                    } catch (e) {
+                      firstException = firstException || e;
+                    }
+                }
+
+                timer = this.firstTimerInRange(previous, tickTo);
+                previous = tickFrom;
+            }
+
+            this.now = tickTo;
+
+            if (firstException) {
+              throw firstException;
+            }
+
+            return this.now;
+        },
+
+        firstTimerInRange: function (from, to) {
+            var timer, smallest = null, originalTimer;
+
+            for (var id in this.timeouts) {
+                if (this.timeouts.hasOwnProperty(id)) {
+                    if (this.timeouts[id].callAt < from || this.timeouts[id].callAt > to) {
+                        continue;
+                    }
+
+                    if (smallest === null || this.timeouts[id].callAt < smallest) {
+                        originalTimer = this.timeouts[id];
+                        smallest = this.timeouts[id].callAt;
+
+                        timer = {
+                            func: this.timeouts[id].func,
+                            callAt: this.timeouts[id].callAt,
+                            interval: this.timeouts[id].interval,
+                            id: this.timeouts[id].id,
+                            invokeArgs: this.timeouts[id].invokeArgs
+                        };
+                    }
+                }
+            }
+
+            return timer || null;
+        },
+
+        callTimer: function (timer) {
+            if (typeof timer.interval == "number") {
+                this.timeouts[timer.id].callAt += timer.interval;
+            } else {
+                delete this.timeouts[timer.id];
+            }
+
+            try {
+                if (typeof timer.func == "function") {
+                    timer.func.apply(null, timer.invokeArgs);
+                } else {
+                    eval(timer.func);
+                }
+            } catch (e) {
+              var exception = e;
+            }
+
+            if (!this.timeouts[timer.id]) {
+                if (exception) {
+                  throw exception;
+                }
+                return;
+            }
+
+            if (exception) {
+              throw exception;
+            }
+        },
+
+        reset: function reset() {
+            this.timeouts = {};
+        },
+
+        Date: (function () {
+            var NativeDate = Date;
+
+            function ClockDate(year, month, date, hour, minute, second, ms) {
+                // Defensive and verbose to avoid potential harm in passing
+                // explicit undefined when user does not pass argument
+                switch (arguments.length) {
+                case 0:
+                    return new NativeDate(ClockDate.clock.now);
+                case 1:
+                    return new NativeDate(year);
+                case 2:
+                    return new NativeDate(year, month);
+                case 3:
+                    return new NativeDate(year, month, date);
+                case 4:
+                    return new NativeDate(year, month, date, hour);
+                case 5:
+                    return new NativeDate(year, month, date, hour, minute);
+                case 6:
+                    return new NativeDate(year, month, date, hour, minute, second);
+                default:
+                    return new NativeDate(year, month, date, hour, minute, second, ms);
+                }
+            }
+
+            return mirrorDateProperties(ClockDate, NativeDate);
+        }())
+    };
+
+    function mirrorDateProperties(target, source) {
+        if (source.now) {
+            target.now = function now() {
+                return target.clock.now;
+            };
+        } else {
+            delete target.now;
+        }
+
+        if (source.toSource) {
+            target.toSource = function toSource() {
+                return source.toSource();
+            };
+        } else {
+            delete target.toSource;
+        }
+
+        target.toString = function toString() {
+            return source.toString();
+        };
+
+        target.prototype = source.prototype;
+        target.parse = source.parse;
+        target.UTC = source.UTC;
+        target.prototype.toUTCString = source.prototype.toUTCString;
+
+        for (var prop in source) {
+            if (source.hasOwnProperty(prop)) {
+                target[prop] = source[prop];
+            }
+        }
+
+        return target;
+    }
+
+    var methods = ["Date", "setTimeout", "setInterval",
+                   "clearTimeout", "clearInterval"];
+
+    if (typeof global.setImmediate !== "undefined") {
+        methods.push("setImmediate");
+    }
+
+    if (typeof global.clearImmediate !== "undefined") {
+        methods.push("clearImmediate");
+    }
+
+    function restore() {
+        var method;
+
+        for (var i = 0, l = this.methods.length; i < l; i++) {
+            method = this.methods[i];
+
+            if (global[method].hadOwnProperty) {
+                global[method] = this["_" + method];
+            } else {
+                try {
+                    delete global[method];
+                } catch (e) {}
+            }
+        }
+
+        // Prevent multiple executions which will completely remove these props
+        this.methods = [];
+    }
+
+    function stubGlobal(method, clock) {
+        clock[method].hadOwnProperty = Object.prototype.hasOwnProperty.call(global, method);
+        clock["_" + method] = global[method];
+
+        if (method == "Date") {
+            var date = mirrorDateProperties(clock[method], global[method]);
+            global[method] = date;
+        } else {
+            global[method] = function () {
+                return clock[method].apply(clock, arguments);
+            };
+
+            for (var prop in clock[method]) {
+                if (clock[method].hasOwnProperty(prop)) {
+                    global[method][prop] = clock[method][prop];
+                }
+            }
+        }
+
+        global[method].clock = clock;
+    }
+
+    sinon.useFakeTimers = function useFakeTimers(now) {
+        var clock = sinon.clock.create(now);
+        clock.restore = restore;
+        clock.methods = Array.prototype.slice.call(arguments,
+                                                   typeof now == "number" ? 1 : 0);
+
+        if (clock.methods.length === 0) {
+            clock.methods = methods;
+        }
+
+        for (var i = 0, l = clock.methods.length; i < l; i++) {
+            stubGlobal(clock.methods[i], clock);
+        }
+
+        return clock;
+    };
+}(typeof global != "undefined" && typeof global !== "function" ? global : this));
+
+sinon.timers = {
+    setTimeout: setTimeout,
+    clearTimeout: clearTimeout,
+    setImmediate: (typeof setImmediate !== "undefined" ? setImmediate : undefined),
+    clearImmediate: (typeof clearImmediate !== "undefined" ? clearImmediate: undefined),
+    setInterval: setInterval,
+    clearInterval: clearInterval,
+    Date: Date
+};
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = sinon;
+}
+
+/**
+ * @depend fake_server.js
+ * @depend fake_timers.js
+ */
+/*jslint browser: true, eqeqeq: false, onevar: false*/
+/*global sinon*/
+/**
+ * Add-on for sinon.fakeServer that automatically handles a fake timer along with
+ * the FakeXMLHttpRequest. The direct inspiration for this add-on is jQuery
+ * 1.3.x, which does not use xhr object's onreadystatehandler at all - instead,
+ * it polls the object for completion with setInterval. Dispite the direct
+ * motivation, there is nothing jQuery-specific in this file, so it can be used
+ * in any environment where the ajax implementation depends on setInterval or
+ * setTimeout.
+ *
+ * @author Christian Johansen (christian@cjohansen.no)
+ * @license BSD
+ *
+ * Copyright (c) 2010-2013 Christian Johansen
+ */
+
+(function () {
+    function Server() {}
+    Server.prototype = sinon.fakeServer;
+
+    sinon.fakeServerWithClock = new Server();
+
+    sinon.fakeServerWithClock.addRequest = function addRequest(xhr) {
+        if (xhr.async) {
+            if (typeof setTimeout.clock == "object") {
+                this.clock = setTimeout.clock;
+            } else {
+                this.clock = sinon.useFakeTimers();
+                this.resetClock = true;
+            }
+
+            if (!this.longestTimeout) {
+                var clockSetTimeout = this.clock.setTimeout;
+                var clockSetInterval = this.clock.setInterval;
+                var server = this;
+
+                this.clock.setTimeout = function (fn, timeout) {
+                    server.longestTimeout = Math.max(timeout, server.longestTimeout || 0);
+
+                    return clockSetTimeout.apply(this, arguments);
+                };
+
+                this.clock.setInterval = function (fn, timeout) {
+                    server.longestTimeout = Math.max(timeout, server.longestTimeout || 0);
+
+                    return clockSetInterval.apply(this, arguments);
+                };
+            }
+        }
+
+        return sinon.fakeServer.addRequest.call(this, xhr);
+    };
+
+    sinon.fakeServerWithClock.respond = function respond() {
+        var returnVal = sinon.fakeServer.respond.apply(this, arguments);
+
+        if (this.clock) {
+            this.clock.tick(this.longestTimeout || 0);
+            this.longestTimeout = 0;
+
+            if (this.resetClock) {
+                this.clock.restore();
+                this.resetClock = false;
+            }
+        }
+
+        return returnVal;
+    };
+
+    sinon.fakeServerWithClock.restore = function restore() {
+        if (this.clock) {
+            this.clock.restore();
+        }
+
+        return sinon.fakeServer.restore.apply(this, arguments);
+    };
+}());
+


### PR DESCRIPTION
JS fetch auth library implementation.

According to @anwar6953 comments next changes are implemented:
1. Browser and NodeJS logic separated into different files;
2. Documentation improved;
3. Minor code corrections.

Files not required to be reviewed( dependecies for tests that could not be installed by 'npm' or 'bower' ):
1. cdap-authentication-clients/javascript/src/base64.js;
2. cdap-authentication-clients/javascript/test/formatio.js;
3. cdap-authentication-clients/javascript/test/samsam.js;
4. cdap-authentication-clients/javascript/test/sinon-server-1.10.3.js.
