### PR TITLE
read readme in setup.py, for rending on pypi

### DIFF
--- a/cdap-authentication-clients/python/README.md
+++ b/cdap-authentication-clients/python/README.md
@@ -35,6 +35,8 @@ To install the development version, clone the repository
     $ cd cdap-clients/cdap-authentication-clients/python/
     $ python setup.py install
 
+Supported Python versions: 2.6, 2.7
+
 ## Usage
 
 To use the Authentication Client Python API, include this import in your Python script:

--- a/cdap-authentication-clients/python/setup.py
+++ b/cdap-authentication-clients/python/setup.py
@@ -17,12 +17,14 @@
 from setuptools import setup
 from setuptools import find_packages
 
+
 setup(name='cdap-auth-client',
       version='1.1.0-SNAPSHOT',
       description='Authentication client for Cask Data Application Platform',
       author='Cask Data',
       author_email='cask-dev@googlegroups.com',
+      url='https://github.com/caskdata/cdap-clients/tree/develop/cdap-authentication-clients/python',
       license='The Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0',
-      install_requires=["six"],
       packages=find_packages(),
+      install_requires=["six"],
       )


### PR DESCRIPTION
It would look something like this (after the contents of the README.md have been translated to rst format):
https://testpypi.python.org/pypi/cdap-auth-client/1.0.1

Same Note as: https://github.com/caskdata/cdap-ingest/pull/89#issue-46588719

EDIT:
Resolution is to simply link to the README on github as Package Documentation on PyPi
https://pypi.python.org/pypi/cdap-auth-client
