### PR TITLE
fixed ruby build - added lib directory into gemspec

### DIFF
--- a/cdap-authentication-clients/ruby/cdap-authentication-client.gemspec
+++ b/cdap-authentication-clients/ruby/cdap-authentication-client.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.files = Dir['lib/**/*']
+  s.files = Dir['lib/**/*.rb']
 end

--- a/cdap-authentication-clients/ruby/cdap-authentication-client.gemspec
+++ b/cdap-authentication-clients/ruby/cdap-authentication-client.gemspec
@@ -33,4 +33,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov-rcov'
 
   s.require_paths = ["lib"]
+
+  s.files = Dir['lib/**/*']
 end


### PR DESCRIPTION
I have added 'lib' directory into 'gemspec' to build and install correct 'cdap-authentication-client.gem'.
