### PR TITLE
Update authentication clients to use v3 ping API and minor other updates

### DIFF
--- a/cdap-authentication-clients/java/src/main/java/co/cask/cdap/security/authentication/client/AbstractAuthenticationClient.java
+++ b/cdap-authentication-clients/java/src/main/java/co/cask/cdap/security/authentication/client/AbstractAuthenticationClient.java
@@ -60,7 +60,7 @@ public abstract class AbstractAuthenticationClient implements AuthenticationClie
 
   private long expirationTime;
   private AccessToken accessToken;
-  private URI baseURI;
+  private URI pingURI;
   private URI authURI;
   private Boolean authEnabled;
   private boolean verifySSLCert;
@@ -89,10 +89,10 @@ public abstract class AbstractAuthenticationClient implements AuthenticationClie
 
   @Override
   public void setConnectionInfo(String host, int port, boolean ssl) {
-    if (baseURI != null) {
+    if (pingURI != null) {
       throw new IllegalStateException("Connection info is already configured!");
     }
-    baseURI = URI.create(String.format("%s://%s:%d/ping", ssl ? HTTPS_PROTOCOL : HTTP_PROTOCOL, host, port));
+    pingURI = URI.create(String.format("%s://%s:%d/ping", ssl ? HTTPS_PROTOCOL : HTTP_PROTOCOL, host, port));
   }
 
   @Override
@@ -151,14 +151,14 @@ public abstract class AbstractAuthenticationClient implements AuthenticationClie
    * @throws IOException IOException in case of a problem or the connection was aborted or if url list is empty
    */
   private String fetchAuthURI() throws IOException {
-    if (baseURI == null) {
+    if (pingURI == null) {
       throw new IllegalStateException("Connection information not set!");
     }
 
-    LOG.debug("Try to get the authentication URI from the gateway server: {}.", baseURI);
-    HttpResponse response = HttpRequests.execute(HttpRequest.get(baseURI.toURL()).build(), getHttpRequestConfig());
+    LOG.debug("Try to get the authentication URI from the gateway server: {}.", pingURI);
+    HttpResponse response = HttpRequests.execute(HttpRequest.get(pingURI.toURL()).build(), getHttpRequestConfig());
 
-    LOG.debug("Got response {} - {} from {}", response.getResponseCode(), response.getResponseMessage(), baseURI);
+    LOG.debug("Got response {} - {} from {}", response.getResponseCode(), response.getResponseMessage(), pingURI);
     if (response.getResponseCode() != HttpURLConnection.HTTP_UNAUTHORIZED) {
       return "";
     }
@@ -188,7 +188,7 @@ public abstract class AbstractAuthenticationClient implements AuthenticationClie
   private AccessToken execute(HttpRequest request) throws IOException {
     HttpResponse response = HttpRequests.execute(request, getHttpRequestConfig());
 
-    LOG.debug("Got response {} - {} from {}", response.getResponseCode(), response.getResponseMessage(), baseURI);
+    LOG.debug("Got response {} - {} from {}", response.getResponseCode(), response.getResponseMessage(), pingURI);
     if (response.getResponseCode() != HttpURLConnection.HTTP_OK) {
       throw new HttpFailureException(response.getResponseMessage(), response.getResponseCode());
     }

--- a/cdap-authentication-clients/java/src/main/java/co/cask/cdap/security/authentication/client/AbstractAuthenticationClient.java
+++ b/cdap-authentication-clients/java/src/main/java/co/cask/cdap/security/authentication/client/AbstractAuthenticationClient.java
@@ -52,7 +52,6 @@ public abstract class AbstractAuthenticationClient implements AuthenticationClie
   private static final String ACCESS_TOKEN_KEY = "access_token";
   private static final String EXPIRES_IN_KEY = "expires_in";
   private static final String TOKEN_TYPE_KEY = "token_type";
-  private static final String DEFAULT_GATEWAY_VERSION = "v3";
   private static final long SPARE_TIME_IN_MILLIS = 5000;
   private static final TypeToken<Map<String, String>> ACCESS_TOKEN_RESPONSE_TYPE_TOKEN
     = new TypeToken<Map<String, String>>() { };
@@ -93,8 +92,7 @@ public abstract class AbstractAuthenticationClient implements AuthenticationClie
     if (baseURI != null) {
       throw new IllegalStateException("Connection info is already configured!");
     }
-    baseURI = URI.create(String.format("%s://%s:%d/%s/ping", ssl ? HTTPS_PROTOCOL : HTTP_PROTOCOL, host, port,
-                                      DEFAULT_GATEWAY_VERSION));
+    baseURI = URI.create(String.format("%s://%s:%d/ping", ssl ? HTTPS_PROTOCOL : HTTP_PROTOCOL, host, port));
   }
 
   @Override

--- a/cdap-authentication-clients/java/src/main/java/co/cask/cdap/security/authentication/client/AbstractAuthenticationClient.java
+++ b/cdap-authentication-clients/java/src/main/java/co/cask/cdap/security/authentication/client/AbstractAuthenticationClient.java
@@ -52,7 +52,7 @@ public abstract class AbstractAuthenticationClient implements AuthenticationClie
   private static final String ACCESS_TOKEN_KEY = "access_token";
   private static final String EXPIRES_IN_KEY = "expires_in";
   private static final String TOKEN_TYPE_KEY = "token_type";
-  private static final String DEFAULT_GATEWAY_VERSION = "v2";
+  private static final String DEFAULT_GATEWAY_VERSION = "v3";
   private static final long SPARE_TIME_IN_MILLIS = 5000;
   private static final TypeToken<Map<String, String>> ACCESS_TOKEN_RESPONSE_TYPE_TOKEN
     = new TypeToken<Map<String, String>>() { };

--- a/cdap-authentication-clients/java/src/test/java/co/cask/cdap/security/authentication/client/basic/BasicAuthenticationClientTestBase.java
+++ b/cdap-authentication-clients/java/src/test/java/co/cask/cdap/security/authentication/client/basic/BasicAuthenticationClientTestBase.java
@@ -292,7 +292,7 @@ public abstract class BasicAuthenticationClientTestBase {
     }
 
     @GET
-    @Path("/v2/ping")
+    @Path("/v3/ping")
     public void testHttpStatus(@SuppressWarnings("UnusedParameters") HttpRequest request,
                                HttpResponder responder) throws Exception {
       if (authEnabled) {

--- a/cdap-authentication-clients/java/src/test/java/co/cask/cdap/security/authentication/client/basic/BasicAuthenticationClientTestBase.java
+++ b/cdap-authentication-clients/java/src/test/java/co/cask/cdap/security/authentication/client/basic/BasicAuthenticationClientTestBase.java
@@ -292,7 +292,7 @@ public abstract class BasicAuthenticationClientTestBase {
     }
 
     @GET
-    @Path("/v3/ping")
+    @Path("/ping")
     public void testHttpStatus(@SuppressWarnings("UnusedParameters") HttpRequest request,
                                HttpResponder responder) throws Exception {
       if (authEnabled) {

--- a/cdap-authentication-clients/javascript/pom.xml
+++ b/cdap-authentication-clients/javascript/pom.xml
@@ -43,6 +43,7 @@
             </goals>
             <configuration>
               <excludes>
+                <exclude>*.rst</exclude>
                 <exclude>*.log</exclude>
                 <exclude>*.sh</exclude>
                 <exclude>*.md</exclude>

--- a/cdap-authentication-clients/javascript/src/authmanager.js
+++ b/cdap-authentication-clients/javascript/src/authmanager.js
@@ -72,9 +72,9 @@
         }
 
         var getAuthHeaders = helpers.getAuthHeaders,
-            baseUrl = [ connectionInfo.ssl ? 'https' : 'http',
+            pingUrl = [ connectionInfo.ssl ? 'https' : 'http',
                         '://', connectionInfo.host,
-                        ':', connectionInfo.port, '/', '/v3/ping'
+                        ':', connectionInfo.port, '/ping'
                         ].join(''),
             fetchAuthUrl = helpers.fetchAuthUrl,
             getAuthUrl = function () {
@@ -88,7 +88,7 @@
                 var retPromise = new Promise();
                 if (null === authEnabled) {
                     if (!authUrls) {
-                        var urlsPromise = fetchAuthUrl(httpConnection, baseUrl);
+                        var urlsPromise = fetchAuthUrl(httpConnection, pingUrl);
                         urlsPromise.then(function (urls) {
                             authUrls = urls || [];
                             authEnabled = !!authUrls.length;

--- a/cdap-authentication-clients/javascript/src/helper-browser.js
+++ b/cdap-authentication-clients/javascript/src/helper-browser.js
@@ -26,7 +26,7 @@ window.CDAPAuthHelpers.Browser = {
 
         return obj;
     },
-    fetchAuthUrl: function (httpConnection, baseUrl) {
+    fetchAuthUrl: function (httpConnection, pingUrl) {
         var promise = new CDAPAuth.Promise();
 
         httpConnection.onreadystatechange = function () {
@@ -36,7 +36,7 @@ window.CDAPAuthHelpers.Browser = {
                 promise.resolve(null);
             }
         };
-        httpConnection.open('GET', baseUrl() + '/v2/ping', true);
+        httpConnection.open('GET', pingUrl, true);
         httpConnection.send();
 
         return promise;

--- a/cdap-authentication-clients/javascript/src/helper-node.js
+++ b/cdap-authentication-clients/javascript/src/helper-node.js
@@ -27,14 +27,14 @@ module.exports = {
 
         return obj;
     },
-    fetchAuthUrl: function (httpConnection, baseUrl) {
+    fetchAuthUrl: function (httpConnection, pingUrl) {
         var promise = new Promise(),
-            parsedUrl = Url.parse(baseUrl()),
+            parsedUrl = Url.parse(pingUrl),
             request = httpConnection.request({
                 protocol: parsedUrl.protocol,
                 host: parsedUrl.hostname,
                 port: parsedUrl.port,
-                path: '/v2/ping',
+                path: parsedUrl.path,
                 method: 'GET'
             }, function (response) {
                 response.setEncoding('utf8');
@@ -53,7 +53,7 @@ module.exports = {
             });
 
         request.on('error', function (error) {
-            promise.resolve(null);
+            promise.reject(error);
         });
 
         request.end();

--- a/cdap-authentication-clients/javascript/test/authmanager-browser.js
+++ b/cdap-authentication-clients/javascript/test/authmanager-browser.js
@@ -103,7 +103,7 @@ describe('CDAP Auth manager tests', function () {
                 "expires_in": 3600
             };
 
-            this.server.respondWith('GET', /\/v2\/ping/, [401, {'Content-Type': 'application/json'}, JSON.stringify({auth_uri: ['/some/url']})]);
+            this.server.respondWith('GET', /\/v3\/ping/, [401, {'Content-Type': 'application/json'}, JSON.stringify({auth_uri: ['/some/url']})]);
             this.server.respondWith('GET', /\/some\/url/, [200, {'Content-Type': 'application/json'}, JSON.stringify(jsonResp)]);
 
             var authManager = new CDAPAuth.Manager(),
@@ -131,7 +131,7 @@ describe('CDAP Auth manager tests', function () {
                     expires_in: 3600
                 };
 
-            this.server.respondWith(/\/v2\/ping$/, [401, {'Content-Type': 'application/json'}, JSON.stringify(jsonRespAuthUrls)]);
+            this.server.respondWith(/\/v3\/ping$/, [401, {'Content-Type': 'application/json'}, JSON.stringify(jsonRespAuthUrls)]);
             this.server.respondWith(/\/token\/url[1-9]*$/, [200, {'Content-Type': 'application/json'},
                 JSON.stringify(jsonRespAuthToken)]);
 

--- a/cdap-authentication-clients/javascript/test/authmanager-browser.js
+++ b/cdap-authentication-clients/javascript/test/authmanager-browser.js
@@ -103,7 +103,7 @@ describe('CDAP Auth manager tests', function () {
                 "expires_in": 3600
             };
 
-            this.server.respondWith('GET', /\/v3\/ping/, [401, {'Content-Type': 'application/json'}, JSON.stringify({auth_uri: ['/some/url']})]);
+            this.server.respondWith('GET', /\/ping/, [401, {'Content-Type': 'application/json'}, JSON.stringify({auth_uri: ['/some/url']})]);
             this.server.respondWith('GET', /\/some\/url/, [200, {'Content-Type': 'application/json'}, JSON.stringify(jsonResp)]);
 
             var authManager = new CDAPAuth.Manager(),
@@ -131,7 +131,7 @@ describe('CDAP Auth manager tests', function () {
                     expires_in: 3600
                 };
 
-            this.server.respondWith(/\/v3\/ping$/, [401, {'Content-Type': 'application/json'}, JSON.stringify(jsonRespAuthUrls)]);
+            this.server.respondWith(/\/ping$/, [401, {'Content-Type': 'application/json'}, JSON.stringify(jsonRespAuthUrls)]);
             this.server.respondWith(/\/token\/url[1-9]*$/, [200, {'Content-Type': 'application/json'},
                 JSON.stringify(jsonRespAuthToken)]);
 

--- a/cdap-authentication-clients/javascript/test/authmanager-spec.js
+++ b/cdap-authentication-clients/javascript/test/authmanager-spec.js
@@ -47,7 +47,7 @@ describe('CDAP Auth manager tests', function () {
                 port = 10000,
 
                 mock = nock('http://' + host + ':' + port)
-                    .get('/v2/ping')
+                    .get('/v3/ping')
                     .reply(200),
 
                 authManager = new CDAPAuthManager(),
@@ -73,7 +73,7 @@ describe('CDAP Auth manager tests', function () {
                     auth_uri: ["/some/url", "/some/url1", "/some/url2"]
                 },
                 mock = nock('http://' + host + ':' + port)
-                    .get('/v2/ping')
+                    .get('/v3/ping')
                     .reply(401, JSON.stringify(jsonResp)),
 
                 authManager = new CDAPAuthManager(),
@@ -107,7 +107,7 @@ describe('CDAP Auth manager tests', function () {
                     "expires_in": 3600
                 },
                 mockAuth = nock('http://' + host + ':' + port).
-                    get('/v2/ping')
+                    get('/v3/ping')
                     .reply(401, JSON.stringify(jsonResp1)),
                 mockToken = nock('http://' + host + ':' + port).
                     get('/token/url')
@@ -143,7 +143,7 @@ describe('CDAP Auth manager tests', function () {
                     expires_in: 3600
                 },
                 mockAuth = nock('http://' + host + ':' + port).
-                    get('/v2/ping')
+                    get('/v3/ping')
                     .reply(401, JSON.stringify(jsonResp1)),
                 mockToken = nock('http://' + host + ':' + port, {
                     reqheaders: {

--- a/cdap-authentication-clients/javascript/test/authmanager-spec.js
+++ b/cdap-authentication-clients/javascript/test/authmanager-spec.js
@@ -47,7 +47,7 @@ describe('CDAP Auth manager tests', function () {
                 port = 10000,
 
                 mock = nock('http://' + host + ':' + port)
-                    .get('/v3/ping')
+                    .get('/ping')
                     .reply(200),
 
                 authManager = new CDAPAuthManager(),
@@ -73,7 +73,7 @@ describe('CDAP Auth manager tests', function () {
                     auth_uri: ["/some/url", "/some/url1", "/some/url2"]
                 },
                 mock = nock('http://' + host + ':' + port)
-                    .get('/v3/ping')
+                    .get('/ping')
                     .reply(401, JSON.stringify(jsonResp)),
 
                 authManager = new CDAPAuthManager(),
@@ -107,7 +107,7 @@ describe('CDAP Auth manager tests', function () {
                     "expires_in": 3600
                 },
                 mockAuth = nock('http://' + host + ':' + port).
-                    get('/v3/ping')
+                    get('/ping')
                     .reply(401, JSON.stringify(jsonResp1)),
                 mockToken = nock('http://' + host + ':' + port).
                     get('/token/url')
@@ -143,7 +143,7 @@ describe('CDAP Auth manager tests', function () {
                     expires_in: 3600
                 },
                 mockAuth = nock('http://' + host + ':' + port).
-                    get('/v3/ping')
+                    get('/ping')
                     .reply(401, JSON.stringify(jsonResp1)),
                 mockToken = nock('http://' + host + ':' + port, {
                     reqheaders: {

--- a/cdap-authentication-clients/python/README.rst
+++ b/cdap-authentication-clients/python/README.rst
@@ -154,4 +154,4 @@ Tests
 
 To run tests from a command line::
  
-  python tests/BasicAuthenticationClientTest.py
+  python tests/basic_authentication_client_test.py

--- a/cdap-authentication-clients/python/cdap_auth_client/abstract_authentication_client.py
+++ b/cdap-authentication-clients/python/cdap_auth_client/abstract_authentication_client.py
@@ -40,7 +40,7 @@ class AbstractAuthenticationClient(AuthenticationClient):
     ACCESS_TOKEN_KEY = u"access_token"
     AUTH_URI_KEY = u"auth_uri"
     AUTHENTICATION_HEADER_PREFIX_BASIC = u"Basic "
-    GATEWAY_VERSION = u'/v2'
+    GATEWAY_VERSION = u'/v3'
     HTTP_PROTOCOL = u"http"
     HTTPS_PROTOCOL = u"https"
     EXPIRES_IN_KEY = u"expires_in"
@@ -81,11 +81,12 @@ class AbstractAuthenticationClient(AuthenticationClient):
         if self.__base_url is None:
             raise ValueError(u"Base authentication"
                              u" client is not configured!")
-        LOG.debug(u"Try to get the authentication URI from "
-                  u"the gateway server: {}.", self.__base_url + self.GATEWAY_VERSION + '/ping')
 
-        response = requests.get(self.__base_url + self.GATEWAY_VERSION + '/ping',
-                                verify=self.ssl_verification_status())
+        ping_uri = self.__base_url + self.GATEWAY_VERSION + '/ping'
+        LOG.debug(u"Try to get the authentication URI from "
+                  u"the gateway server: {}.", ping_uri)
+
+        response = requests.get(ping_uri, verify=self.ssl_verification_status())
         result = None
         if response.status_code == hl.UNAUTHORIZED:
             uri_list = response.json()[self.AUTH_URI_KEY]

--- a/cdap-authentication-clients/python/cdap_auth_client/abstract_authentication_client.py
+++ b/cdap-authentication-clients/python/cdap_auth_client/abstract_authentication_client.py
@@ -40,7 +40,6 @@ class AbstractAuthenticationClient(AuthenticationClient):
     ACCESS_TOKEN_KEY = u"access_token"
     AUTH_URI_KEY = u"auth_uri"
     AUTHENTICATION_HEADER_PREFIX_BASIC = u"Basic "
-    GATEWAY_VERSION = u'/v3'
     HTTP_PROTOCOL = u"http"
     HTTPS_PROTOCOL = u"https"
     EXPIRES_IN_KEY = u"expires_in"
@@ -82,7 +81,7 @@ class AbstractAuthenticationClient(AuthenticationClient):
             raise ValueError(u"Base authentication"
                              u" client is not configured!")
 
-        ping_uri = self.__base_url + self.GATEWAY_VERSION + '/ping'
+        ping_uri = self.__base_url + '/ping'
         LOG.debug(u"Try to get the authentication URI from "
                   u"the gateway server: {}.", ping_uri)
 

--- a/cdap-authentication-clients/ruby/lib/cdap-authentication-client/authentication_client.rb
+++ b/cdap-authentication-clients/ruby/lib/cdap-authentication-client/authentication_client.rb
@@ -28,7 +28,7 @@ module AuthenticationClient
 
     def initialize
       @rest = AuthClientRest.new
-      @base_url = nil
+      @ping_url = nil
       @auth_url = nil
       @is_auth_enabled = nil
       @access_token = nil
@@ -51,15 +51,15 @@ module AuthenticationClient
     end
 
     def set_connection_info(host, port, ssl)
-      if @base_url
+      if @ping_url
         fail IllegalStateException.new, 'Connection info is already configured!'
       end
       protocol = ssl ? 'https' : 'http'
-      @base_url = "#{protocol}://#{host}:#{port}"
+      @ping_url = "#{protocol}://#{host}:#{port}/ping"
     end
 
     def fetch_auth_url
-      req = rest.get(@base_url, @ssl_cert_check)
+      req = rest.get(@ping_url, @ssl_cert_check)
       auth_urls = req ['auth_uri']
       if auth_urls.empty?
         fail AuthenticationServerNotFoundException.new 'No Authentication server to get a token from was found'

--- a/cdap-authentication-clients/ruby/lib/cdap-authentication-client/authentication_client.rb
+++ b/cdap-authentication-clients/ruby/lib/cdap-authentication-client/authentication_client.rb
@@ -59,7 +59,7 @@ module AuthenticationClient
     end
 
     def fetch_auth_url
-      req = rest.get(@base_url + '/v2/ping', @ssl_cert_check)
+      req = rest.get(@base_url + '/v3/ping', @ssl_cert_check)
       auth_urls = req ['auth_uri']
       if auth_urls.empty?
         fail AuthenticationServerNotFoundException.new 'No Authentication server to get a token from was found'

--- a/cdap-authentication-clients/ruby/lib/cdap-authentication-client/authentication_client.rb
+++ b/cdap-authentication-clients/ruby/lib/cdap-authentication-client/authentication_client.rb
@@ -59,7 +59,7 @@ module AuthenticationClient
     end
 
     def fetch_auth_url
-      req = rest.get(@base_url + '/v3/ping', @ssl_cert_check)
+      req = rest.get(@base_url, @ssl_cert_check)
       auth_urls = req ['auth_uri']
       if auth_urls.empty?
         fail AuthenticationServerNotFoundException.new 'No Authentication server to get a token from was found'

--- a/cdap-authentication-clients/ruby/spec/fixtures/vcr_cassettes/authentication_client_get_auth_enabled.yml
+++ b/cdap-authentication-clients/ruby/spec/fixtures/vcr_cassettes/authentication_client_get_auth_enabled.yml
@@ -16,7 +16,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://127.0.0.1:11000/v2/ping
+    uri: http://127.0.0.1:11000/v3/ping
     body:
       encoding: US-ASCII
       string: ''

--- a/cdap-authentication-clients/ruby/spec/fixtures/vcr_cassettes/authentication_client_get_auth_enabled.yml
+++ b/cdap-authentication-clients/ruby/spec/fixtures/vcr_cassettes/authentication_client_get_auth_enabled.yml
@@ -16,7 +16,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://127.0.0.1:11000/v3/ping
+    uri: http://127.0.0.1:11000/ping
     body:
       encoding: US-ASCII
       string: ''

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <gson.version>2.2.4</gson.version>
     <guava.version>13.0.1</guava.version>
     <junit.version>4.11</junit.version>
-    <cask.common.version>0.1.0</cask.common.version>
+    <cask.common.version>0.1.1</cask.common.version>
     <netty.http.version>0.4.0</netty.http.version>
     <commons.codec.version>1.6</commons.codec.version>
   </properties>
@@ -200,7 +200,7 @@
                 <excludes>
                   <exclude>build-number.txt</exclude>
                   <exclude>LICENSE*.txt</exclude>
-                  <exclude>*.rst</exclude>
+                  <exclude>**/*.rst</exclude>
                   <exclude>**/*.md</exclude>
                   <exclude>**/*.json</exclude>
                   <exclude>logs/**</exclude>


### PR DESCRIPTION
- Upgrade auth clients to use v3 ping API
- Bump version of cask.common used
- propagate errors (for example, if improper hostname is given). Before, errors were being suppressed (not visible to the user at all).
