### PR TITLE
Rename AuthenticationClient module to CDAP

### DIFF
--- a/cdap-authentication-clients/ruby/README.rst
+++ b/cdap-authentication-clients/ruby/README.rst
@@ -35,9 +35,9 @@ If you use the gem outside Rails, you should require gem files in your applicati
 
 Examples
 ========
-Create a ``CDAPIngest::AuthenticationClient`` instance::
+Create a ``CDAP::AuthenticationClient`` instance::
 
-  authentication_client = CDAPIngest::AuthenticationClient.new
+  authentication_client = CDAP::AuthenticationClient.new
 
 Set the connection parameters (authentication server host, authentication server host
 port, SSL mode)::
@@ -55,6 +55,10 @@ Load the configuration from the file::
 
   config = YAML.load_file('spec/auth.yml')
 
+Setting the configuration in Ruby::
+
+  config = { 'security.auth.client.username' => 'admin', 'security.auth.client.password' => 'secret', 'security.auth.client.ssl_cert_check' => true }
+
 Configure the authentication client::
 
   authentication_client.configure(config)
@@ -62,7 +66,7 @@ Configure the authentication client::
 Check if authentication is enabled in the gateway server::
 
   is_enabled = authentication_client.is_auth_enabled
-                    
+
 Retrieve the access token from the authentication server::
 
   token = authentication_client.get_access_token

--- a/cdap-authentication-clients/ruby/cdap-authentication-client.gemspec
+++ b/cdap-authentication-clients/ruby/cdap-authentication-client.gemspec
@@ -19,8 +19,8 @@ require "cdap-authentication-client/version"
 Gem::Specification.new do |s|
   s.name        = "cdap-authentication-client"
   s.version     = CDAP::VERSION
-  s.authors     = ["Yura Tolochkevych"]
-  s.email       = ["ytolochkevych@cask.co"]
+  s.authors     = ["Cask Data, Inc."]
+  s.email       = ["ops@cask.co"]
   s.summary     = "A Ruby client for authentication in Cask CDAP services"
   s.description = "Provide a more Ruby experience when using authentication in Cask CDAP services."
 

--- a/cdap-authentication-clients/ruby/cdap-authentication-client.gemspec
+++ b/cdap-authentication-clients/ruby/cdap-authentication-client.gemspec
@@ -1,4 +1,4 @@
-#  Copyright © 2014 Cask Data, Inc.
+#  Copyright © 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -18,7 +18,7 @@ require "cdap-authentication-client/version"
 
 Gem::Specification.new do |s|
   s.name        = "cdap-authentication-client"
-  s.version     = AuthenticationClient::VERSION
+  s.version     = CDAP::VERSION
   s.authors     = ["Yura Tolochkevych"]
   s.email       = ["ytolochkevych@cask.co"]
   s.summary     = "A Ruby client for authentication in Cask CDAP services"

--- a/cdap-authentication-clients/ruby/lib/cdap-authentication-client.rb
+++ b/cdap-authentication-clients/ruby/lib/cdap-authentication-client.rb
@@ -14,7 +14,7 @@
 
 require 'httparty'
 
-module AuthenticationClient
+module CDAP
   
 end
 

--- a/cdap-authentication-clients/ruby/lib/cdap-authentication-client/access_token.rb
+++ b/cdap-authentication-clients/ruby/lib/cdap-authentication-client/access_token.rb
@@ -1,4 +1,4 @@
-#  Copyright © 2014 Cask Data, Inc.
+#  Copyright © 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -12,7 +12,7 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-module AuthenticationClient
+module CDAP
   ###
   #  This class represents access token object.
   class AccessToken

--- a/cdap-authentication-clients/ruby/lib/cdap-authentication-client/auth_client_rest.rb
+++ b/cdap-authentication-clients/ruby/lib/cdap-authentication-client/auth_client_rest.rb
@@ -1,4 +1,4 @@
-#  Copyright © 2014 Cask Data, Inc.
+#  Copyright © 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -14,7 +14,7 @@
 
 require 'httparty'
 
-module AuthenticationClient
+module CDAP
   ###
   # The helper class for providing http requests
   class AuthClientRest

--- a/cdap-authentication-clients/ruby/lib/cdap-authentication-client/authentication_client.rb
+++ b/cdap-authentication-clients/ruby/lib/cdap-authentication-client/authentication_client.rb
@@ -1,4 +1,4 @@
-#  Copyright © 2014 Cask Data, Inc.
+#  Copyright © 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -12,7 +12,7 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-module AuthenticationClient
+module CDAP
   require 'cdap-authentication-client/authentication_client_interface'
   ###
   # The client class to fetch access token from the authentication server

--- a/cdap-authentication-clients/ruby/lib/cdap-authentication-client/authentication_client_interface.rb
+++ b/cdap-authentication-clients/ruby/lib/cdap-authentication-client/authentication_client_interface.rb
@@ -1,4 +1,4 @@
-#  Copyright © 2014 Cask Data, Inc.
+#  Copyright © 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -12,7 +12,7 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-module AuthenticationClient
+module CDAP
 
   class AuthenticationClientInterface
 

--- a/cdap-authentication-clients/ruby/lib/cdap-authentication-client/credential.rb
+++ b/cdap-authentication-clients/ruby/lib/cdap-authentication-client/credential.rb
@@ -1,4 +1,4 @@
-#  Copyright © 2014 Cask Data, Inc.
+#  Copyright © 2014-2015 Cask Data, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not
 #  use this file except in compliance with the License. You may obtain a copy of
@@ -12,7 +12,7 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-module AuthenticationClient
+module CDAP
 
   class Credential
 

--- a/cdap-authentication-clients/ruby/lib/cdap-authentication-client/version.rb
+++ b/cdap-authentication-clients/ruby/lib/cdap-authentication-client/version.rb
@@ -12,6 +12,6 @@
 #  License for the specific language governing permissions and limitations under
 #  the License.
 
-module AuthenticationClient
+module CDAP
   VERSION = '1.3.0.a.1'
 end

--- a/cdap-authentication-clients/ruby/spec/lib/cdap-authentication-client/authentication_client_spec.rb
+++ b/cdap-authentication-clients/ruby/spec/lib/cdap-authentication-client/authentication_client_spec.rb
@@ -14,19 +14,19 @@
 
 require 'spec_helper'
 
-describe AuthenticationClient::AuthenticationClient do
-  let(:authentication_client) { AuthenticationClient::AuthenticationClient.new }
+describe CDAP::AuthenticationClient do
+  let(:authentication_client) { CDAP::AuthenticationClient.new }
   before do
     authentication_client.set_connection_info('127.0.0.1', 11000, false)
   end
 
   it 'instance check' do
     VCR.insert_cassette('authentication_client')
-    expect(authentication_client).to be_a AuthenticationClient::AuthenticationClient
+    expect(authentication_client).to be_a CDAP::AuthenticationClient
     VCR.eject_cassette
   end
 
-  it { expect(AuthenticationClient::AuthenticationClient).to respond_to(:new) }
+  it { expect(CDAP::AuthenticationClient).to respond_to(:new) }
 
   it { expect(authentication_client).to respond_to(:get_access_token) }
 
@@ -38,7 +38,7 @@ describe AuthenticationClient::AuthenticationClient do
     VCR.eject_cassette
     VCR.insert_cassette('authentication_client_get_access_token')
     token = authentication_client.get_access_token
-    expect(token.class).to eq AuthenticationClient::AccessToken
+    expect(token.class).to eq CDAP::AccessToken
     expect(token.value).to be_a String
     expect(token.token_type).to eq 'Bearer'
     expect(token.expires_in).to eq 86_400

--- a/cdap-authentication-clients/ruby/spec/lib/cdap-authentication-client/rest_spec.rb
+++ b/cdap-authentication-clients/ruby/spec/lib/cdap-authentication-client/rest_spec.rb
@@ -14,13 +14,13 @@
 
 require 'spec_helper'
 
-describe AuthenticationClient::AuthClientRest do
+describe CDAP::AuthClientRest do
 
-  let(:rest) { VCR.use_cassette('rest') { AuthenticationClient::AuthClientRest.new } }
+  let(:rest) { VCR.use_cassette('rest') { CDAP::AuthClientRest.new } }
 
-  it { expect(rest).to be_a AuthenticationClient::AuthClientRest }
+  it { expect(rest).to be_a CDAP::AuthClientRest }
 
-  it { expect(AuthenticationClient::AuthClientRest).to respond_to(:new) }
+  it { expect(CDAP::AuthClientRest).to respond_to(:new) }
 
   it { expect(rest).to respond_to(:get) }
 


### PR DESCRIPTION
This means you instantiate `CDAP::AuthenticationClient` instead of `AuthenticationClient::AuthenticationClient` (the docs were wrong, anyway)...
