### PR TITLE
Fix to be compatible with earlier version of python-logging

### DIFF
--- a/cdap-authentication-clients/python/cdap_auth_client/abstract_authentication_client.py
+++ b/cdap-authentication-clients/python/cdap_auth_client/abstract_authentication_client.py
@@ -83,7 +83,7 @@ class AbstractAuthenticationClient(AuthenticationClient):
 
         ping_uri = self.__base_url + '/ping'
         LOG.debug(u"Try to get the authentication URI from "
-                  u"the gateway server: {}.", ping_uri)
+                  u"the gateway server: %s." % ping_uri)
 
         response = requests.get(ping_uri, verify=self.ssl_verification_status())
         result = None
@@ -115,7 +115,7 @@ class AbstractAuthenticationClient(AuthenticationClient):
                 request_time + self.__access_token.expires_in\
                 - self.SPARE_TIME_IN_MILLIS
             LOG.debug(u"Received the access token successfully."
-                      u" Expiration date is {}.",
+                      u" Expiration date is %s" %
                       datetime.datetime.
                       fromtimestamp(self.__expiration_time/1000)
                       .strftime(u'%Y-%m-%d %H:%M:%S.%f'))

--- a/cdap-authentication-clients/python/cdap_auth_client/basic_authentication_client.py
+++ b/cdap-authentication-clients/python/cdap_auth_client/basic_authentication_client.py
@@ -65,7 +65,7 @@ class BasicAuthenticationClient(AbstractAuthenticationClient):
             raise ValueError(u'Base authentication client'
                              u' is not configured!')
         LOG.debug(u'Authentication is enabled in the gateway server.'
-                  u' Authentication URI {}.', self.auth_url)
+                  u' Authentication URI %s.' % self.auth_url)
         base64string = base64.b64encode(
             (u'%s:%s' % (self.__username, self.__password)).encode('utf-8'))
         auth_header = json.dumps(


### PR DESCRIPTION
LOG.debug("-----{}-----", "----") syntax is not compatible with early version of python logging. Earlier logging module use old-styled operator %s to format string [https://docs.python.org/3/library/logging.html#logging.Logger.debug](https://docs.python.org/3/library/logging.html#logging.Logger.debug). Change three lines of code to construct the debug logging string in advance before passing to logging module. 
